### PR TITLE
feat: add Fit to Width and Fit to Height PDF zoom options

### DIFF
--- a/apps/desktop/src/components/workspace/preview/pdf-preview.tsx
+++ b/apps/desktop/src/components/workspace/preview/pdf-preview.tsx
@@ -22,6 +22,7 @@ import {
   Select,
   SelectContent,
   SelectItem,
+  SelectSeparator,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
@@ -31,6 +32,8 @@ import { compileLatex, synctexEdit } from "@/lib/latex-compiler";
 import { SelectionToolbar, type ToolbarAction } from "@/components/workspace/editor/selection-toolbar";
 import { save } from "@tauri-apps/plugin-dialog";
 import type { PdfTextSelection, CaptureResult } from "./pdf-viewer";
+
+type FitMode = "fit-width" | "fit-height" | null;
 
 const ZOOM_OPTIONS = [
   { value: "0.5", label: "50%" },
@@ -73,6 +76,9 @@ export function PdfPreview() {
   const [numPages, setNumPages] = useState<number>(0);
   const [scale, setScale] = useState<number>(1.0);
   const [captureMode, setCaptureMode] = useState(false);
+  const [fitMode, setFitMode] = useState<FitMode>(null);
+  const [containerSize, setContainerSize] = useState<{ width: number; height: number } | null>(null);
+  const [firstPageSize, setFirstPageSize] = useState<{ width: number; height: number } | null>(null);
   const hasInitialCompile = useRef(false);
   const initialized = useDocumentStore((s) => s.initialized);
 
@@ -293,8 +299,21 @@ export function PdfPreview() {
     compile();
   }, [initialized, projectRoot, pdfData, isCompiling, compileError, setIsCompiling, setPdfData, setCompileError, saveAllFiles, files, activeFile]);
 
-  const zoomIn = () => setScale((s) => Math.min(4, s + 0.1));
-  const zoomOut = () => setScale((s) => Math.max(0.25, s - 0.1));
+  // Recompute scale when fit mode is active and container/page size changes
+  useEffect(() => {
+    if (!fitMode || !containerSize || !firstPageSize) return;
+    const PADDING = 32; // p-4 on each side
+    if (fitMode === "fit-width") {
+      const newScale = (containerSize.width - PADDING) / firstPageSize.width;
+      setScale(Math.max(0.25, Math.min(4, newScale)));
+    } else if (fitMode === "fit-height") {
+      const newScale = (containerSize.height - PADDING) / firstPageSize.height;
+      setScale(Math.max(0.25, Math.min(4, newScale)));
+    }
+  }, [fitMode, containerSize, firstPageSize]);
+
+  const zoomIn = () => { setFitMode(null); setScale((s) => Math.min(4, s + 0.1)); };
+  const zoomOut = () => { setFitMode(null); setScale((s) => Math.max(0.25, s - 0.1)); };
 
   const handleExport = async () => {
     if (!pdfData) return;
@@ -312,7 +331,7 @@ export function PdfPreview() {
   };
 
   const handleLoadSuccess = (pages: number) => setNumPages(pages);
-  const handleScaleChange = (newScale: number) => setScale(newScale);
+  const handleScaleChange = (newScale: number) => { setFitMode(null); setScale(newScale); };
 
   const handleCompile = async () => {
     if (isCompiling || !projectRoot || !isTexActive) return;
@@ -469,6 +488,8 @@ export function PdfPreview() {
           onTextClick={handleTextClick}
           onSynctexClick={handleSynctexClick}
           onTextSelect={handleTextSelect}
+          onFirstPageSize={(w, h) => setFirstPageSize({ width: w, height: h })}
+          onContainerResize={(w, h) => setContainerSize({ width: w, height: h })}
           captureMode={captureMode}
           onCapture={handleCapture}
           onCancelCapture={() => setCaptureMode(false)}
@@ -513,9 +534,28 @@ export function PdfPreview() {
               <span className="mr-1.5 text-muted-foreground text-xs">{numPages} {numPages === 1 ? "page" : "pages"}</span>
               <Button variant="ghost" size="icon" className="size-7" onClick={zoomOut} disabled={scale <= 0.25}><MinusIcon className="size-3.5" /></Button>
               <Button variant="ghost" size="icon" className="size-7" onClick={zoomIn} disabled={scale >= 4}><PlusIcon className="size-3.5" /></Button>
-              <Select value={scale.toString()} onValueChange={(v) => setScale(Number(v))}>
-                <SelectTrigger size="sm" className="h-7! w-auto text-xs"><SelectValue>{Math.round(scale * 100)}%</SelectValue></SelectTrigger>
-                <SelectContent>{ZOOM_OPTIONS.map((opt) => (<SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>))}</SelectContent>
+              <Select
+                value={fitMode ?? scale.toString()}
+                onValueChange={(v) => {
+                  if (v === "fit-width" || v === "fit-height") {
+                    setFitMode(v);
+                  } else {
+                    setFitMode(null);
+                    setScale(Number(v));
+                  }
+                }}
+              >
+                <SelectTrigger size="sm" className="h-7! w-auto text-xs">
+                  <SelectValue>
+                    {fitMode === "fit-width" ? "Fit width" : fitMode === "fit-height" ? "Fit height" : `${Math.round(scale * 100)}%`}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent position="popper" align="end">
+                  <SelectItem value="fit-width">Fit to width</SelectItem>
+                  <SelectItem value="fit-height">Fit to height</SelectItem>
+                  <SelectSeparator />
+                  {ZOOM_OPTIONS.map((opt) => (<SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>))}
+                </SelectContent>
               </Select>
               <div className="mx-1 h-4 w-px bg-border" />
               {/* Capture mode */}

--- a/apps/desktop/src/components/workspace/preview/pdf-viewer.tsx
+++ b/apps/desktop/src/components/workspace/preview/pdf-viewer.tsx
@@ -31,6 +31,7 @@ interface PdfViewerProps {
   onSynctexClick?: (page: number, x: number, y: number) => void;
   onTextSelect?: (selection: PdfTextSelection | null) => void;
   onFirstPageSize?: (width: number, height: number) => void;
+  onContainerResize?: (width: number, height: number) => void;
   captureMode?: boolean;
   onCapture?: (result: CaptureResult) => void;
   onCancelCapture?: () => void;
@@ -46,6 +47,7 @@ export function PdfViewer({
   onSynctexClick,
   onTextSelect,
   onFirstPageSize,
+  onContainerResize,
   captureMode = false,
   onCapture,
   onCancelCapture,
@@ -219,6 +221,18 @@ export function PdfViewer({
 
     return () => observer.disconnect();
   }, [pageSizes, scale]);
+
+  // Report container dimensions to parent for fit-to-width/height
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !onContainerResize) return;
+    const ro = new ResizeObserver((entries) => {
+      const { width, height } = entries[0].contentRect;
+      onContainerResize(width, height);
+    });
+    ro.observe(container);
+    return () => ro.disconnect();
+  }, [onContainerResize]);
 
   // Native dblclick listener for synctex
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Add "Fit to width" and "Fit to height" options at the top of the PDF zoom dropdown, separated from percentage presets
- Fit modes dynamically recalculate scale on window/container resize and persist during scroll
- Manual zoom (buttons, wheel, keyboard, percentage select) clears fit mode
- Fix bouncy scroll arrow in dropdown by switching to popper positioning

## Test plan
- [ ] Open a PDF and select "Fit to width" -- PDF fills container width
- [ ] Select "Fit to height" -- one full page fits vertically
- [ ] Resize the window while in fit mode -- scale updates automatically
- [ ] Scroll through pages -- fit mode stays active
- [ ] Use +/- buttons or Cmd+scroll -- fit mode clears, returns to percentage
- [ ] Dropdown no longer shows bouncy arrow at top

Generated with [Claude Code](https://claude.com/claude-code)