### PR TITLE
chore: add package-lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 node_modules
 .pnp
 .pnp.js
+package-lock.json
 
 # Local env files
 .env


### PR DESCRIPTION
## Summary
- Add `package-lock.json` to `.gitignore` since the project uses pnpm (`pnpm-lock.yaml`)
- Prevents stray npm lock files from being accidentally committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)