### PR TITLE
fix: address Copilot review on PR #24 — update comments and add binary extension tests

### DIFF
--- a/apps/desktop/src/__tests__/lib/tauri-fs.test.ts
+++ b/apps/desktop/src/__tests__/lib/tauri-fs.test.ts
@@ -22,6 +22,15 @@ describe("getFileType logic", () => {
     ".aux", ".log", ".out", ".toc", ".lof", ".lot", ".fls",
     ".fdb_latexmk", ".synctex.gz", ".synctex", ".blg", ".bbl",
     ".nav", ".snm", ".vrb", ".run.xml", ".bcf",
+    // Binary / non-text files
+    ".hwp", ".hwpx", ".doc", ".docx", ".xls", ".xlsx", ".xlsm",
+    ".ppt", ".pptx", ".accdb", ".mdb",
+    ".zip", ".rar", ".7z", ".tar", ".gz",
+    ".exe", ".dll", ".so", ".dylib", ".o", ".obj",
+    ".bin", ".dat", ".iso", ".dmg", ".msi",
+    ".mp3", ".mp4", ".avi", ".mov", ".mkv", ".wav", ".flac",
+    ".psd", ".ai", ".sketch", ".fig",
+    ".sqlite", ".db",
   ]);
 
   function getFileType(name: string): string | null {
@@ -76,6 +85,21 @@ describe("getFileType logic", () => {
     expect(getFileType("main.synctex.gz")).toBeNull();
     expect(getFileType("main.fdb_latexmk")).toBeNull();
     expect(getFileType("main.bbl")).toBeNull();
+  });
+
+  it("ignores binary and non-text files", () => {
+    expect(getFileType("document.docx")).toBeNull();
+    expect(getFileType("spreadsheet.xlsx")).toBeNull();
+    expect(getFileType("report.hwp")).toBeNull();
+    expect(getFileType("data.accdb")).toBeNull();
+    expect(getFileType("archive.zip")).toBeNull();
+    expect(getFileType("app.exe")).toBeNull();
+    expect(getFileType("song.mp3")).toBeNull();
+    expect(getFileType("video.mp4")).toBeNull();
+    expect(getFileType("image.psd")).toBeNull();
+    expect(getFileType("database.sqlite")).toBeNull();
+    expect(getFileType("library.dll")).toBeNull();
+    expect(getFileType("presentation.pptx")).toBeNull();
   });
 
   it("classifies unknown extensions as other", () => {

--- a/apps/desktop/src/lib/tauri/fs.ts
+++ b/apps/desktop/src/lib/tauri/fs.ts
@@ -47,7 +47,7 @@ const STYLE_EXTENSIONS = new Set([
 ]);
 
 const IGNORED_EXTENSIONS = new Set([
-  // LaTeX build artifacts
+  // Ignored file extensions: LaTeX build artifacts and other non-editable/binary files
   ".aux",
   ".log",
   ".out",
@@ -110,7 +110,7 @@ const IGNORED_EXTENSIONS = new Set([
 
 function getFileType(name: string): ProjectFileType | null {
   const lower = name.toLowerCase();
-  // Skip LaTeX build artifacts
+  // Skip ignored file extensions (build artifacts, binary/non-text files)
   for (const ext of IGNORED_EXTENSIONS) {
     if (lower.endsWith(ext)) return null;
   }


### PR DESCRIPTION
## Summary
- Update `IGNORED_EXTENSIONS` comment from "LaTeX build artifacts" to accurately reflect it now includes general non-editable/binary file types
- Update `getFileType` inline comment to match the broader scope of ignored extensions
- Add Vitest coverage for representative new binary extensions (`.docx`, `.xlsx`, `.hwp`, `.accdb`, `.zip`, `.exe`, `.mp3`, `.mp4`, `.psd`, `.sqlite`, `.dll`, `.pptx`) ensuring they return `null`

Addresses Copilot review comments from #24.

## Test plan
- [x] All 8 existing + new tests pass (`vitest run`)
- [ ] Verify binary files (`.docx`, `.xlsx`, `.hwp`, etc.) do not appear in sidebar file tree
- [ ] Verify existing file types (`.tex`, `.bib`, `.pdf`, images) still load normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)