### PR TITLE
fix: correct download URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@
 </p>
 
 <p align="center">
-  <a href="https://claude-prism-landing.delibae.workers.dev">Website</a> ·
-  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism_aarch64.dmg">macOS</a> ·
-  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism_x64-setup.msi">Windows</a> ·
-  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism_amd64.deb">Linux</a> ·
+  <a href="https://claudeprism.delibae.dev?utm_source=github&utm_medium=readme&utm_campaign=launch_v054">Website</a> ·
+  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism_1.0.0_aarch64.dmg">macOS</a> ·
+  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism_1.0.0_x64-setup.exe">Windows</a> ·
+  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism_1.0.0_amd64.deb">Linux</a> ·
   <a href="https://github.com/delibae/claude-prism/releases">All Releases</a>
 </p>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,10 +19,10 @@
 </p>
 
 <p align="center">
-  <a href="https://claude-prism-landing.delibae.workers.dev">官网</a> ·
-  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism_aarch64.dmg">macOS</a> ·
-  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism_x64-setup.msi">Windows</a> ·
-  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism_amd64.deb">Linux</a> ·
+  <a href="https://claudeprism.delibae.dev?utm_source=github&utm_medium=readme&utm_campaign=launch_v054">官网</a> ·
+  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism_1.0.0_aarch64.dmg">macOS</a> ·
+  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism_1.0.0_x64-setup.exe">Windows</a> ·
+  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism_1.0.0_amd64.deb">Linux</a> ·
   <a href="https://github.com/delibae/claude-prism/releases">所有版本</a>
 </p>
 


### PR DESCRIPTION
## Summary
- README 및 README.zh-CN 의 다운로드 링크가 실제 릴리스 에셋 파일명과 불일치하는 문제 수정
- 버전 prefix (`1.0.0`) 추가 (macOS, Windows, Linux)
- Windows 인스톨러를 `.msi` → `.exe`로 변경 (일반 사용자에게 더 적합)

## Test plan
- [ ] 각 다운로드 링크가 실제 릴리스 에셋으로 연결되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)