### PR TITLE
fix: resolve Windows process spawn and CLI detection issues

### DIFF
--- a/apps/desktop/src-tauri/src/claude.rs
+++ b/apps/desktop/src-tauri/src/claude.rs
@@ -7,6 +7,11 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 
+/// Windows CREATE_NO_WINDOW flag to prevent console windows from flashing
+/// when spawning child processes (e.g. Claude CLI, cmd.exe, node.exe).
+#[cfg(target_os = "windows")]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
 #[derive(Clone)]
 pub struct ClaudeProcessState {
     pub processes: Arc<Mutex<HashMap<String, Child>>>,
@@ -26,6 +31,9 @@ fn find_claude_binary() -> Result<String, String> {
     // 1. Check the native installer's default location first
     //    (GUI apps often don't have ~/.local/bin in PATH)
     if let Some(home) = dirs::home_dir() {
+        #[cfg(target_os = "windows")]
+        let native_path = home.join(".local").join("bin").join("claude.exe");
+        #[cfg(not(target_os = "windows"))]
         let native_path = home.join(".local").join("bin").join("claude");
         if native_path.exists() {
             return Ok(native_path.to_string_lossy().to_string());
@@ -137,6 +145,58 @@ fn find_claude_binary() -> Result<String, String> {
     Ok("claude".to_string())
 }
 
+/// Strip ANSI escape sequences from CLI output before sending to the frontend.
+/// Handles CSI sequences (e.g. colors, cursor), OSC sequences, and private mode
+/// sequences like `\x1b[?2026h` emitted by modern CLIs.
+fn strip_ansi(s: &str) -> Cow<'_, str> {
+    if !s.contains('\x1b') {
+        return Cow::Borrowed(s);
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            match chars.peek() {
+                // CSI: ESC [ ... (letter)
+                Some('[') => {
+                    chars.next();
+                    // consume until final byte (ASCII letter or ~)
+                    while let Some(&ch) = chars.peek() {
+                        chars.next();
+                        if ch.is_ascii_alphabetic() || ch == '~' {
+                            break;
+                        }
+                    }
+                }
+                // OSC: ESC ] ... (ST or BEL)
+                Some(']') => {
+                    chars.next();
+                    while let Some(&ch) = chars.peek() {
+                        chars.next();
+                        if ch == '\x07' {
+                            break;
+                        }
+                        if ch == '\x1b' {
+                            if chars.peek() == Some(&'\\') {
+                                chars.next();
+                            }
+                            break;
+                        }
+                    }
+                }
+                // Two-character sequences: ESC ( , ESC ) , etc.
+                Some(&ch) if ch.is_ascii_alphabetic() || ch == '(' || ch == ')' => {
+                    chars.next();
+                }
+                _ => {}
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    Cow::Owned(out)
+}
+
 /// Strip interior nul bytes that would cause Command::spawn() to fail.
 /// This can happen when prompts contain clipboard artifacts or encoding issues.
 /// Returns a borrowed reference when no nul bytes are present (zero-alloc fast path).
@@ -186,8 +246,10 @@ fn resolve_cmd_to_node(program: &str) -> (String, Vec<String>) {
 fn new_sync_command(program: &str) -> std::process::Command {
     #[cfg(target_os = "windows")]
     {
+        use std::os::windows::process::CommandExt;
         let (resolved, prefix) = resolve_cmd_to_node(program);
         let mut c = std::process::Command::new(&resolved);
+        c.creation_flags(CREATE_NO_WINDOW);
         if !prefix.is_empty() {
             c.args(&prefix);
         }
@@ -205,8 +267,10 @@ fn create_command(program: &str, args: Vec<String>, cwd: &str, effort_level: Opt
 
     #[cfg(target_os = "windows")]
     let mut cmd = {
+        use std::os::windows::process::CommandExt;
         let (resolved, prefix) = resolve_cmd_to_node(clean_program.as_ref());
         let mut c = Command::new(&resolved);
+        c.creation_flags(CREATE_NO_WINDOW);
         if !prefix.is_empty() {
             c.args(&prefix);
         }
@@ -621,7 +685,9 @@ pub async fn install_claude_cli(window: WebviewWindow) -> Result<(), String> {
     };
     #[cfg(target_os = "windows")]
     let mut cmd = {
+        use std::os::windows::process::CommandExt;
         let mut c = tokio::process::Command::new("powershell");
+        c.creation_flags(CREATE_NO_WINDOW);
         c.args(["-NoProfile", "-Command", "irm https://claude.ai/install.ps1 | iex"]);
         c
     };
@@ -629,6 +695,10 @@ pub async fn install_claude_cli(window: WebviewWindow) -> Result<(), String> {
     cmd.stderr(std::process::Stdio::piped());
 
     // Inherit essential environment variables, ensuring ~/.local/bin is in PATH
+    #[cfg(target_os = "windows")]
+    let path_sep = ";";
+    #[cfg(not(target_os = "windows"))]
+    let path_sep = ":";
     for (key, value) in std::env::vars() {
         if key == "PATH" {
             // Prepend ~/.local/bin so the installer sees it in PATH
@@ -636,7 +706,7 @@ pub async fn install_claude_cli(window: WebviewWindow) -> Result<(), String> {
                 let local_bin = home.join(".local").join("bin");
                 let local_bin_str = local_bin.to_string_lossy();
                 if !value.contains(local_bin_str.as_ref()) {
-                    cmd.env("PATH", format!("{}:{}", local_bin_str, value));
+                    cmd.env("PATH", format!("{}{}{}", local_bin_str, path_sep, value));
                 } else {
                     cmd.env("PATH", &value);
                 }
@@ -674,7 +744,8 @@ pub async fn install_claude_cli(window: WebviewWindow) -> Result<(), String> {
     let stdout_task = tokio::spawn(async move {
         let mut lines = stdout_reader.lines();
         while let Ok(Some(line)) = lines.next_line().await {
-            let _ = win_stdout.emit("install-output", &line);
+            let clean = strip_ansi(&line);
+            let _ = win_stdout.emit("install-output", clean.as_ref());
         }
     });
 
@@ -683,7 +754,8 @@ pub async fn install_claude_cli(window: WebviewWindow) -> Result<(), String> {
     let stderr_task = tokio::spawn(async move {
         let mut lines = stderr_reader.lines();
         while let Ok(Some(line)) = lines.next_line().await {
-            let _ = win_stderr.emit("install-error", &line);
+            let clean = strip_ansi(&line);
+            let _ = win_stderr.emit("install-error", clean.as_ref());
         }
     });
 
@@ -720,8 +792,10 @@ pub async fn login_claude(window: WebviewWindow) -> Result<(), String> {
 
     #[cfg(target_os = "windows")]
     let mut cmd = {
+        use std::os::windows::process::CommandExt;
         let (resolved, prefix) = resolve_cmd_to_node(&binary_path);
         let mut c = tokio::process::Command::new(&resolved);
+        c.creation_flags(CREATE_NO_WINDOW);
         if !prefix.is_empty() {
             c.args(&prefix);
         }
@@ -771,7 +845,8 @@ pub async fn login_claude(window: WebviewWindow) -> Result<(), String> {
     let stdout_task = tokio::spawn(async move {
         let mut lines = stdout_reader.lines();
         while let Ok(Some(line)) = lines.next_line().await {
-            let _ = win_stdout.emit("login-output", &line);
+            let clean = strip_ansi(&line);
+            let _ = win_stdout.emit("login-output", clean.as_ref());
         }
     });
 
@@ -780,7 +855,8 @@ pub async fn login_claude(window: WebviewWindow) -> Result<(), String> {
     let stderr_task = tokio::spawn(async move {
         let mut lines = stderr_reader.lines();
         while let Ok(Some(line)) = lines.next_line().await {
-            let _ = win_stderr.emit("login-error", &line);
+            let clean = strip_ansi(&line);
+            let _ = win_stderr.emit("login-error", clean.as_ref());
         }
     });
 

--- a/apps/desktop/src-tauri/src/slash_commands.rs
+++ b/apps/desktop/src-tauri/src/slash_commands.rs
@@ -91,7 +91,7 @@ fn extract_command_info(file_path: &Path, base_path: &Path) -> Option<(String, O
         .to_string_lossy()
         .to_string();
 
-    let components: Vec<&str> = path_without_ext.split('/').collect();
+    let components: Vec<&str> = path_without_ext.split(['/', '\\']).collect();
 
     if components.is_empty() {
         return None;

--- a/apps/desktop/src-tauri/src/uv.rs
+++ b/apps/desktop/src-tauri/src/uv.rs
@@ -2,6 +2,11 @@ use std::path::PathBuf;
 use tauri::{Emitter, WebviewWindow};
 use tokio::io::{AsyncBufReadExt, BufReader};
 
+/// Windows CREATE_NO_WINDOW flag to prevent console windows from flashing
+/// when spawning child processes (e.g. uv, powershell, python).
+#[cfg(target_os = "windows")]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
 // ─── Binary Discovery ───
 
 /// Discover the uv binary on the system.
@@ -132,9 +137,14 @@ pub async fn check_uv_status() -> Result<UvStatus, String> {
     };
 
     // Verify binary actually works by running --version
-    let version_output = std::process::Command::new(&binary_path)
-        .arg("--version")
-        .output();
+    let mut version_cmd = std::process::Command::new(&binary_path);
+    version_cmd.arg("--version");
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        version_cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    let version_output = version_cmd.output();
 
     let version = match version_output {
         Ok(output) if output.status.success() => {
@@ -197,7 +207,9 @@ pub async fn install_uv(window: WebviewWindow) -> Result<(), String> {
     };
     #[cfg(target_os = "windows")]
     let mut cmd = {
+        use std::os::windows::process::CommandExt;
         let mut c = tokio::process::Command::new("powershell");
+        c.creation_flags(CREATE_NO_WINDOW);
         c.args([
             "-NoProfile",
             "-Command",
@@ -291,9 +303,15 @@ pub async fn setup_project_venv(project_path: String) -> Result<VenvInfo, String
     let uv_bin = find_uv_binary().map_err(|e| format!("uv not found: {}", e))?;
 
     // Create venv: uv venv <project_path>/.venv
-    let output = tokio::process::Command::new(&uv_bin)
-        .args(["venv", &venv_dir.to_string_lossy()])
-        .current_dir(project)
+    let mut venv_cmd = tokio::process::Command::new(&uv_bin);
+    venv_cmd.args(["venv", &venv_dir.to_string_lossy()]);
+    venv_cmd.current_dir(project);
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        venv_cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    let output = venv_cmd
         .output()
         .await
         .map_err(|e| format!("Failed to create venv: {}", e))?;
@@ -327,11 +345,17 @@ pub async fn uv_add_packages(
     let mut args = vec!["pip".to_string(), "install".to_string()];
     args.extend(packages);
 
-    let output = tokio::process::Command::new(&uv_bin)
-        .args(&args)
-        .current_dir(&project_path)
-        .env("VIRTUAL_ENV", &venv_dir)
-        .env("PATH", path_with_venv(&venv_dir))
+    let mut pip_cmd = tokio::process::Command::new(&uv_bin);
+    pip_cmd.args(&args);
+    pip_cmd.current_dir(&project_path);
+    pip_cmd.env("VIRTUAL_ENV", &venv_dir);
+    pip_cmd.env("PATH", path_with_venv(&venv_dir));
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        pip_cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    let output = pip_cmd
         .output()
         .await
         .map_err(|e| format!("Failed to run uv pip install: {}", e))?;
@@ -365,11 +389,17 @@ pub async fn uv_run_command(
     let program = parts.first().ok_or("Empty command")?;
     let args = parts.get(1..).unwrap_or_default();
 
-    let output = tokio::process::Command::new(program)
-        .args(args)
-        .current_dir(&project_path)
-        .env("VIRTUAL_ENV", &venv_dir)
-        .env("PATH", path_with_venv(&venv_dir))
+    let mut run_cmd = tokio::process::Command::new(program);
+    run_cmd.args(args);
+    run_cmd.current_dir(&project_path);
+    run_cmd.env("VIRTUAL_ENV", &venv_dir);
+    run_cmd.env("PATH", path_with_venv(&venv_dir));
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        run_cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    let output = run_cmd
         .output()
         .await
         .map_err(|e| format!("Failed to run command: {}", e))?;


### PR DESCRIPTION
## Summary
- **Console window flashing**: Add `CREATE_NO_WINDOW` (0x08000000) flag to all 9 child process spawn sites on Windows (`claude.rs`, `uv.rs`) to prevent blank cmd.exe/powershell windows from appearing
- **Claude CLI not found after install**: Native installer puts binary at `~/.local/bin/claude.exe` but detection code was checking for `claude` (no extension) — fixed with `#[cfg]` platform guard
- **Broken PATH on Windows**: `install_claude_cli` was using `:` as PATH separator instead of `;`
- **ANSI garbage in UI**: Added `strip_ansi()` filter for terminal escape sequences (`[?2026h`, color codes, etc.) in install/login output streams
- **Slash commands broken on Windows**: Path component splitting used `/` only — now handles `\` too

## Test plan
- [ ] Windows: Install Claude Code via app → no blank console window appears
- [ ] Windows: After install, app correctly detects `claude.exe` in `~/.local/bin/`
- [ ] Windows: Install/login log output is clean (no `[?2026h` escape sequences)
- [ ] Windows: Slash commands with namespaces parse correctly
- [ ] macOS: No regression — all existing flows work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)