### PR TITLE
ci: preserve existing release assets on Windows build

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -81,8 +81,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Build and release
-        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Build Tauri app
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -92,22 +91,25 @@ jobs:
           projectPath: apps/desktop
           tauriScript: pnpm tauri
           args: --target x86_64-pc-windows-msvc
-          tagName: ${{ github.ref_name }}
-          releaseName: "ClaudePrism ${{ github.ref_name }}"
-          releaseDraft: false
-          prerelease: false
 
-      - name: Build only (no release)
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-        uses: tauri-apps/tauri-action@v0
+      - name: Upload to existing release
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ZOTERO_CONSUMER_KEY: ${{ secrets.ZOTERO_CONSUMER_KEY }}
-          ZOTERO_CONSUMER_SECRET: ${{ secrets.ZOTERO_CONSUMER_SECRET }}
-        with:
-          projectPath: apps/desktop
-          tauriScript: pnpm tauri
-          args: --target x86_64-pc-windows-msvc
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          BUNDLE_DIR="apps/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle"
+
+          # Create release if it doesn't exist yet, otherwise leave it alone
+          gh release view "$TAG" > /dev/null 2>&1 || \
+            gh release create "$TAG" --title "ClaudePrism $TAG" --generate-notes
+
+          # Upload assets — overwrites if same filename already exists
+          find "$BUNDLE_DIR" -type f \( -name "*.exe" -o -name "*.msi" \) | while read -r file; do
+            echo "Uploading: $file"
+            gh release upload "$TAG" "$file" --clobber
+          done
 
       - name: Upload artifacts (manual builds)
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
## Summary
- **Problem**: `tauri-action` recreates the entire GitHub release when Windows build runs, deleting previously uploaded macOS/Linux assets
- **Fix**: Removed `tauri-action`'s release management (`tagName`, `releaseName`, etc.) and replaced with `gh release` CLI that:
  - Creates a release only if one doesn't exist (`gh release view || gh release create`)
  - Uploads Windows `.exe`/`.msi` with `--clobber` (overwrites same filename, preserves other platform files)

## Test plan
- [ ] Tag push: Windows build uploads to existing release without removing macOS/Linux assets
- [ ] `workflow_dispatch`: Still builds and uploads as artifact (no release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)