### PR TITLE
fix: detect missing Git for Windows and guide users to install it

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -2,6 +2,11 @@ name: Build Windows
 
 on:
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Upload to this release tag (e.g. v1.0.0). Leave empty for artifact-only build."
+        required: false
+        default: ""
   push:
     tags:
       - "v*"
@@ -92,13 +97,25 @@ jobs:
           tauriScript: pnpm tauri
           args: --target x86_64-pc-windows-msvc
 
-      - name: Upload to existing release
-        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Determine release tag
+        id: tag
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          elif [[ -n "${{ inputs.release_tag }}" ]]; then
+            echo "tag=${{ inputs.release_tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload to release
+        if: steps.tag.outputs.tag != ''
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
+          TAG="${{ steps.tag.outputs.tag }}"
           BUNDLE_DIR="apps/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle"
 
           # Create release if it doesn't exist yet, otherwise leave it alone
@@ -111,8 +128,8 @@ jobs:
             gh release upload "$TAG" "$file" --clobber
           done
 
-      - name: Upload artifacts (manual builds)
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+      - name: Upload artifacts
+        if: steps.tag.outputs.tag == ''
         uses: actions/upload-artifact@v4
         with:
           name: desktop-windows

--- a/apps/desktop/src-tauri/src/claude.rs
+++ b/apps/desktop/src-tauri/src/claude.rs
@@ -492,10 +492,56 @@ pub struct ClaudeStatus {
     pub binary_path: Option<String>,
     pub version: Option<String>,
     pub account_email: Option<String>,
+    /// Windows only: true when Git for Windows (git-bash) is not found.
+    /// Claude Code requires git-bash to function on Windows.
+    pub missing_git: bool,
+}
+
+/// Check whether Git for Windows (git-bash) is available on Windows.
+#[cfg(target_os = "windows")]
+fn is_git_bash_available() -> bool {
+    // 1. User-specified override
+    if let Ok(p) = std::env::var("CLAUDE_CODE_GIT_BASH_PATH") {
+        if PathBuf::from(&p).exists() {
+            return true;
+        }
+    }
+
+    // 2. Common install locations
+    let candidates = [
+        r"C:\Program Files\Git\bin\bash.exe",
+        r"C:\Program Files (x86)\Git\bin\bash.exe",
+    ];
+    for path in &candidates {
+        if PathBuf::from(path).exists() {
+            return true;
+        }
+    }
+
+    // 3. git on PATH → derive bash.exe location
+    if let Ok(git_path) = which::which("git") {
+        // git.exe is typically at Git/cmd/git.exe → bash.exe at Git/bin/bash.exe
+        if let Some(cmd_dir) = git_path.parent() {
+            if let Some(git_root) = cmd_dir.parent() {
+                if git_root.join("bin").join("bash.exe").exists() {
+                    return true;
+                }
+            }
+        }
+    }
+
+    // 4. bash directly on PATH
+    which::which("bash").is_ok()
 }
 
 #[tauri::command]
 pub async fn check_claude_status() -> Result<ClaudeStatus, String> {
+    // On Windows, check for Git for Windows first — Claude Code requires it.
+    #[cfg(target_os = "windows")]
+    let missing_git = !is_git_bash_available();
+    #[cfg(not(target_os = "windows"))]
+    let missing_git = false;
+
     // Try to find binary
     let binary_path = match find_claude_binary() {
         Ok(path) => path,
@@ -506,6 +552,7 @@ pub async fn check_claude_status() -> Result<ClaudeStatus, String> {
                 binary_path: None,
                 version: None,
                 account_email: None,
+                missing_git,
             });
         }
     };
@@ -520,13 +567,15 @@ pub async fn check_claude_status() -> Result<ClaudeStatus, String> {
             Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
         }
         _ => {
-            // Binary found but doesn't work (bare "claude" fallback or broken install)
+            // Binary found but doesn't work — on Windows this is often because
+            // Git for Windows is missing (Claude Code needs git-bash).
             return Ok(ClaudeStatus {
                 installed: false,
                 authenticated: false,
                 binary_path: None,
                 version: None,
                 account_email: None,
+                missing_git,
             });
         }
     };
@@ -561,6 +610,7 @@ pub async fn check_claude_status() -> Result<ClaudeStatus, String> {
         binary_path: Some(binary_path),
         version,
         account_email,
+        missing_git,
     })
 }
 

--- a/apps/desktop/src-tauri/src/uv.rs
+++ b/apps/desktop/src-tauri/src/uv.rs
@@ -235,6 +235,20 @@ pub async fn install_uv(window: WebviewWindow) -> Result<(), String> {
             || key == "HTTPS_PROXY"
             || key == "NO_PROXY"
             || key == "ALL_PROXY"
+            // Windows-essential variables
+            || key == "USERPROFILE"
+            || key == "LOCALAPPDATA"
+            || key == "APPDATA"
+            || key == "TEMP"
+            || key == "TMP"
+            || key == "SystemRoot"
+            || key == "WINDIR"
+            || key == "PROGRAMFILES"
+            || key == "PROGRAMFILES(X86)"
+            || key == "COMMONPROGRAMFILES"
+            || key == "SystemDrive"
+            || key == "COMPUTERNAME"
+            || key == "USERNAME"
         {
             cmd.env(&key, &value);
         }

--- a/apps/desktop/src/components/claude-setup.tsx
+++ b/apps/desktop/src/components/claude-setup.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useCallback } from "react";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import {
   DownloadIcon,
@@ -11,7 +11,10 @@ import {
   TerminalIcon,
   CircleIcon,
   ChevronRightIcon,
+  GitBranchIcon,
+  ExternalLinkIcon,
 } from "lucide-react";
+import { open as shellOpen } from "@tauri-apps/plugin-shell";
 import { Button } from "@/components/ui/button";
 import { useClaudeSetupStore, type StepInfo } from "@/stores/claude-setup-store";
 import { cn } from "@/lib/utils";
@@ -340,6 +343,43 @@ export function ClaudeSetup() {
         >
           <RefreshCwIcon className="size-3.5" />
           {hasInstallSteps ? "Retry Installation" : "Retry"}
+        </Button>
+      </div>
+    );
+  }
+
+  if (status === "missing-git") {
+    return (
+      <div className="flex w-full flex-col gap-3 rounded-xl border border-amber-500/30 bg-amber-500/5 px-5 py-4">
+        <div className="flex items-center gap-2">
+          <GitBranchIcon className="size-5 shrink-0 text-amber-600" />
+          <div>
+            <p className="text-sm font-medium">Git for Windows Required</p>
+            <p className="text-xs text-muted-foreground">
+              Claude Code needs Git for Windows (git-bash) to work.
+              Please install it first, then click "I've installed Git".
+            </p>
+          </div>
+        </div>
+        <Button
+          size="sm"
+          variant="outline"
+          className="w-full gap-2"
+          onClick={() => {
+            shellOpen("https://git-scm.com/downloads/win");
+          }}
+        >
+          <ExternalLinkIcon className="size-3.5" />
+          Download Git for Windows
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="w-full gap-2 text-muted-foreground"
+          onClick={checkStatus}
+        >
+          <RefreshCwIcon className="size-3.5" />
+          I've installed Git
         </Button>
       </div>
     );

--- a/apps/desktop/src/stores/claude-setup-store.ts
+++ b/apps/desktop/src/stores/claude-setup-store.ts
@@ -9,10 +9,12 @@ interface ClaudeStatus {
   binary_path: string | null;
   version: string | null;
   account_email: string | null;
+  missing_git: boolean;
 }
 
 type SetupStatus =
   | "checking"
+  | "missing-git"
   | "not-installed"
   | "not-authenticated"
   | "ready"
@@ -110,6 +112,12 @@ export const useClaudeSetupStore = create<ClaudeSetupState>((set, get) => ({
     set({ status: "checking", error: null });
     try {
       const result = await invoke<ClaudeStatus>("check_claude_status");
+
+      // On Windows, Git for Windows is required before anything else
+      if (result.missing_git) {
+        set({ status: "missing-git", version: null, accountEmail: null });
+        return;
+      }
 
       if (!result.installed) {
         set({ status: "not-installed", version: null, accountEmail: null });


### PR DESCRIPTION
## Summary
- Windows users without Git for Windows were stuck in an "Install Claude Code" loop because Claude Code requires git-bash but the app never checked for it
- Added `is_git_bash_available()` check on Windows that looks for bash.exe in common Git install paths, PATH, and `CLAUDE_CODE_GIT_BASH_PATH` env var
- New `missing-git` setup status shows a dedicated UI with "Download Git for Windows" link and "I've installed Git" re-check button
- Also: added Windows-essential env vars to uv installer, improved CI workflow with manual `release_tag` input

## Test plan
- [ ] On Windows without Git for Windows: verify "Git for Windows Required" screen appears
- [ ] Click "Download Git for Windows" → opens https://git-scm.com/downloads/win in browser
- [ ] After installing Git, click "I've installed Git" → proceeds to Claude Code install/auth flow
- [ ] On Windows with Git already installed: verify normal flow is unaffected
- [ ] On macOS/Linux: verify `missing_git` is always `false`, no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)