### PR TITLE
fix: Windows titlebar, installer fixes, and responsive PDF toolbar

### DIFF
--- a/apps/desktop/src-tauri/src/claude.rs
+++ b/apps/desktop/src-tauri/src/claude.rs
@@ -738,7 +738,7 @@ pub async fn install_claude_cli(window: WebviewWindow) -> Result<(), String> {
         use std::os::windows::process::CommandExt;
         let mut c = tokio::process::Command::new("powershell");
         c.creation_flags(CREATE_NO_WINDOW);
-        c.args(["-NoProfile", "-Command", "irm https://claude.ai/install.ps1 | iex"]);
+        c.args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", "irm https://claude.ai/install.ps1 | iex"]);
         c
     };
     cmd.stdout(std::process::Stdio::piped());

--- a/apps/desktop/src-tauri/src/uv.rs
+++ b/apps/desktop/src-tauri/src/uv.rs
@@ -26,8 +26,10 @@ fn find_uv_binary() -> Result<String, String> {
         ];
         #[cfg(target_os = "windows")]
         let user_paths = vec![
+            // uv's default install location (same as Claude Code)
+            home.join(".local").join("bin").join("uv.exe"),
             home.join(".cargo").join("bin").join("uv.exe"),
-            // uv's default Windows install location
+            // %LOCALAPPDATA%\uv\bin\uv.exe
             PathBuf::from(
                 std::env::var("LOCALAPPDATA").unwrap_or_else(|_| {
                     home.join("AppData").join("Local").to_string_lossy().to_string()
@@ -212,6 +214,7 @@ pub async fn install_uv(window: WebviewWindow) -> Result<(), String> {
         c.creation_flags(CREATE_NO_WINDOW);
         c.args([
             "-NoProfile",
+            "-ExecutionPolicy", "Bypass",
             "-Command",
             "irm https://astral.sh/uv/install.ps1 | iex",
         ]);

--- a/apps/desktop/src/components/workspace/preview/pdf-preview.tsx
+++ b/apps/desktop/src/components/workspace/preview/pdf-preview.tsx
@@ -631,8 +631,8 @@ export function PdfPreview() {
   };
 
   return (
-    <div ref={previewContainerRef} className="relative flex h-full flex-col bg-muted/50">
-      <div className="flex items-center overflow-hidden border-border border-b bg-background px-2 pt-[var(--titlebar-height)] h-[calc(40px+var(--titlebar-height))]">
+    <div ref={previewContainerRef} className="@container/pv relative flex h-full flex-col bg-muted/50">
+      <div className="flex shrink-0 items-center border-border border-b bg-background px-2 pt-[var(--titlebar-height)] h-[calc(40px+var(--titlebar-height))]">
         <div className="flex items-center gap-1">
           {isSaving && (
             <div className="flex items-center gap-1.5 rounded-md bg-muted/50 px-2 py-1">
@@ -727,31 +727,30 @@ export function PdfPreview() {
               <Button
                 variant={captureMode ? "default" : "secondary"}
                 size="sm"
-                className={`h-7 gap-1.5 px-2.5 text-xs ${
+                className={`h-7 gap-1.5 px-2 text-xs ${
                   captureMode
                     ? "ring-2 ring-primary/30"
                     : "bg-foreground text-background hover:bg-foreground/90"
                 }`}
                 onClick={() => setCaptureMode(!captureMode)}
+                title={`Capture & Ask (${navigator.userAgent.includes("Mac") ? "⌘X" : "Ctrl+X"})`}
               >
-                <CrosshairIcon className="size-3.5" />
-                Capture & Ask
-                <kbd className="pointer-events-none ml-0.5 rounded border border-background/30 bg-background/20 px-1.5 py-0.5 text-xs font-medium leading-none text-background">
+                <CrosshairIcon className="size-3.5 shrink-0" />
+                <span className="hidden @[36rem]/pv:inline">Capture & Ask</span>
+                <kbd className="pointer-events-none ml-0.5 hidden rounded border border-background/30 bg-background/20 px-1 py-0.5 text-[10px] font-medium leading-none text-background @[36rem]/pv:inline">
                   {navigator.userAgent.includes("Mac") ? "⌘X" : "Ctrl+X"}
                 </kbd>
               </Button>
               <div className="mx-1 h-4 w-px bg-border" />
-              <Button variant="ghost" size="sm" className="h-7 gap-1.5 px-2.5 text-xs" onClick={handleExport} title="Export PDF">
+              <Button variant="ghost" size="icon" className="size-7" onClick={handleExport} title="Export PDF">
                 <DownloadIcon className="size-3.5" />
-                Export
               </Button>
             </>
           )}
           <Popover>
             <PopoverTrigger asChild>
-              <Button variant="ghost" size="sm" className="h-7 gap-1.5 px-2.5 text-xs" title="History">
+              <Button variant="ghost" size="icon" className="size-7" title="History">
                 <HistoryIcon className="size-3.5" />
-                History
               </Button>
             </PopoverTrigger>
             <PopoverContent align="end" className="w-96">

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -9,8 +9,13 @@ window.addEventListener("unhandledrejection", (event) => {
   console.error("[unhandledrejection]", event.reason);
 });
 
-// On non-macOS platforms, reset titlebar height (no overlay titlebar)
-if (!navigator.userAgent.includes("Macintosh")) {
+// Platform-specific titlebar height adjustments
+if (navigator.userAgent.includes("Windows")) {
+  // Windows overlay titlebar is ~32px (title + window controls)
+  document.documentElement.style.setProperty("--titlebar-height", "32px");
+  document.documentElement.style.setProperty("--traffic-light-width", "0px");
+} else if (!navigator.userAgent.includes("Macintosh")) {
+  // Linux and others: no overlay titlebar
   document.documentElement.style.setProperty("--titlebar-height", "0px");
   document.documentElement.style.setProperty("--traffic-light-width", "0px");
 }


### PR DESCRIPTION
## Summary
Changes that were missed from PR #37 squash merge:
- Set `--titlebar-height` to 32px on Windows (was 0px, content hidden behind native overlay titlebar)
- Add `-ExecutionPolicy Bypass` to PowerShell installers (uv + Claude Code) to prevent silent failures
- Add `~/.local/bin/uv.exe` to Windows uv binary search paths
- PDF toolbar: Export/History as icon-only, Capture & Ask text hidden on narrow panels via `@container` query

## Test plan
- [ ] Windows: content not hidden behind titlebar
- [ ] Windows: uv install works with restricted ExecutionPolicy
- [ ] Narrow PDF preview: toolbar items don't overflow, Capture shows icon only
- [ ] Wide PDF preview: full "Capture & Ask ⌘X" text visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)