### PR TITLE
fix: show folder name only in sidebar on Windows

### DIFF
--- a/apps/desktop/src/components/workspace/sidebar.tsx
+++ b/apps/desktop/src/components/workspace/sidebar.tsx
@@ -546,7 +546,7 @@ export function Sidebar() {
         <div className="flex flex-col items-center">
           <span className="font-semibold text-sm">ClaudePrism</span>
           <span className="text-muted-foreground text-xs">
-            {projectRoot?.split("/").pop() || "Desktop"}
+            {projectRoot?.split(/[/\\]/).pop() || "Desktop"}
           </span>
         </div>
         <div className="absolute right-3 flex items-center gap-0.5">


### PR DESCRIPTION
## Summary
- `projectRoot.split("/")` didn't handle Windows backslash paths, showing full path in sidebar header
- Now splits on both `/` and `\` so only the folder name is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)