### PR TITLE
feat: auto-updater and macOS black screen fix (v1.0.1)

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -1,4 +1,4 @@
-name: Build Windows
+name: Build Desktop
 
 on:
   workflow_dispatch:
@@ -14,13 +14,17 @@ on:
 permissions:
   contents: write
 
+env:
+  TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+
 jobs:
+  # ──────────────────────────────────────────────
+  # Windows
+  # ──────────────────────────────────────────────
   build-windows:
     runs-on: windows-latest
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -64,76 +68,333 @@ jobs:
           echo "CXXFLAGS=/std:c++17" >> $GITHUB_ENV
           echo "CFLAGS=" >> $GITHUB_ENV
 
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-pc-windows-msvc
 
-      - name: Rust cache
-        uses: swatinem/rust-cache@v2
+      - uses: swatinem/rust-cache@v2
         with:
           workspaces: apps/desktop/src-tauri -> target
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
 
-      - name: Install dependencies
-        run: pnpm install
+      - run: pnpm install
 
       - name: Build Tauri app
-        uses: tauri-apps/tauri-action@v0
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ZOTERO_CONSUMER_KEY: ${{ secrets.ZOTERO_CONSUMER_KEY }}
           ZOTERO_CONSUMER_SECRET: ${{ secrets.ZOTERO_CONSUMER_SECRET }}
-        with:
-          projectPath: apps/desktop
-          tauriScript: pnpm tauri
-          args: --target x86_64-pc-windows-msvc
+        run: pnpm --filter @claude-prism/desktop tauri build --target x86_64-pc-windows-msvc
 
-      - name: Determine release tag
-        id: tag
+      - name: Collect updater artifacts
+        id: collect
         shell: bash
         run: |
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-          elif [[ -n "${{ inputs.release_tag }}" ]]; then
-            echo "tag=${{ inputs.release_tag }}" >> $GITHUB_OUTPUT
-          else
-            echo "tag=" >> $GITHUB_OUTPUT
+          BUNDLE="apps/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle"
+          NSIS_SIG=$(find "$BUNDLE/nsis" -name '*.nsis.zip.sig' 2>/dev/null | head -1)
+          NSIS_ZIP=$(find "$BUNDLE/nsis" -name '*.nsis.zip' ! -name '*.sig' 2>/dev/null | head -1)
+
+          if [ -n "$NSIS_SIG" ] && [ -n "$NSIS_ZIP" ]; then
+            echo "sig=$(cat "$NSIS_SIG")" >> $GITHUB_OUTPUT
+            echo "url=$(basename "$NSIS_ZIP")" >> $GITHUB_OUTPUT
           fi
 
-      - name: Upload to release
-        if: steps.tag.outputs.tag != ''
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TAG="${{ steps.tag.outputs.tag }}"
-          BUNDLE_DIR="apps/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle"
-
-          # Create release if it doesn't exist yet, otherwise leave it alone
-          gh release view "$TAG" > /dev/null 2>&1 || \
-            gh release create "$TAG" --title "ClaudePrism $TAG" --generate-notes
-
-          # Upload assets — overwrites if same filename already exists
-          find "$BUNDLE_DIR" -type f \( -name "*.exe" -o -name "*.msi" \) | while read -r file; do
-            echo "Uploading: $file"
-            gh release upload "$TAG" "$file" --clobber
-          done
-
-      - name: Upload artifacts
-        if: steps.tag.outputs.tag == ''
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: desktop-windows
           path: |
             apps/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/**/*.exe
             apps/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/**/*.msi
+            apps/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/**/*.nsis.zip
+            apps/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/**/*.sig
           if-no-files-found: warn
+
+    outputs:
+      sig: ${{ steps.collect.outputs.sig }}
+      url: ${{ steps.collect.outputs.url }}
+
+  # ──────────────────────────────────────────────
+  # macOS (Apple Silicon)
+  # ──────────────────────────────────────────────
+  build-macos:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install macOS dependencies
+        run: brew install icu4c harfbuzz pkg-config
+
+      - name: Import Apple certificate
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+
+          # Create temporary keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Import certificate
+          echo "$APPLE_CERTIFICATE" | base64 --decode > $RUNNER_TEMP/certificate.p12
+          security import $RUNNER_TEMP/certificate.p12 \
+            -k "$KEYCHAIN_PATH" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain-db
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: apps/desktop/src-tauri -> target
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install
+
+      - name: Build Tauri app
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ZOTERO_CONSUMER_KEY: ${{ secrets.ZOTERO_CONSUMER_KEY }}
+          ZOTERO_CONSUMER_SECRET: ${{ secrets.ZOTERO_CONSUMER_SECRET }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          TECTONIC_DEP_BACKEND: vcpkg
+          VCPKG_ROOT: /usr/local/share/vcpkg
+          CXXFLAGS: "-std=c++17"
+          CFLAGS: ""
+        run: pnpm --filter @claude-prism/desktop tauri build --target aarch64-apple-darwin
+
+      - name: Notarize DMG
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+        run: |
+          TARGET="aarch64-apple-darwin"
+          BUNDLE="apps/desktop/src-tauri/target/$TARGET/release/bundle"
+          DMG_PATH=$(find "$BUNDLE/dmg" -name '*.dmg' | head -1)
+          APP_PATH="$BUNDLE/macos/ClaudePrism.app"
+
+          if [ -z "$DMG_PATH" ]; then
+            echo "Error: DMG not found"
+            exit 1
+          fi
+
+          echo "==> Notarizing $DMG_PATH ..."
+          xcrun notarytool submit "$DMG_PATH" \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_PASSWORD" \
+            --wait --timeout 30m
+
+          echo "==> Stapling..."
+          xcrun stapler staple "$DMG_PATH"
+          xcrun stapler staple "$APP_PATH"
+
+      - name: Collect updater artifacts
+        id: collect
+        run: |
+          BUNDLE="apps/desktop/src-tauri/target/aarch64-apple-darwin/release/bundle"
+          TAR_SIG=$(find "$BUNDLE/macos" -name '*.app.tar.gz.sig' 2>/dev/null | head -1)
+          TAR_GZ=$(find "$BUNDLE/macos" -name '*.app.tar.gz' ! -name '*.sig' 2>/dev/null | head -1)
+
+          if [ -n "$TAR_SIG" ] && [ -n "$TAR_GZ" ]; then
+            echo "sig=$(cat "$TAR_SIG")" >> $GITHUB_OUTPUT
+            echo "url=$(basename "$TAR_GZ")" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-macos
+          path: |
+            apps/desktop/src-tauri/target/aarch64-apple-darwin/release/bundle/**/*.dmg
+            apps/desktop/src-tauri/target/aarch64-apple-darwin/release/bundle/**/*.app.tar.gz
+            apps/desktop/src-tauri/target/aarch64-apple-darwin/release/bundle/**/*.sig
+          if-no-files-found: warn
+
+    outputs:
+      sig: ${{ steps.collect.outputs.sig }}
+      url: ${{ steps.collect.outputs.url }}
+
+  # ──────────────────────────────────────────────
+  # Linux
+  # ──────────────────────────────────────────────
+  build-linux:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf \
+            libicu-dev libgraphite2-dev libharfbuzz-dev libfreetype-dev libfontconfig-dev
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: apps/desktop/src-tauri -> target
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install
+
+      - name: Build Tauri app
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ZOTERO_CONSUMER_KEY: ${{ secrets.ZOTERO_CONSUMER_KEY }}
+          ZOTERO_CONSUMER_SECRET: ${{ secrets.ZOTERO_CONSUMER_SECRET }}
+          TECTONIC_DEP_BACKEND: pkg-config
+          CXXFLAGS: "-std=c++17"
+          CFLAGS: ""
+        run: pnpm --filter @claude-prism/desktop tauri build --target x86_64-unknown-linux-gnu
+
+      - name: Collect updater artifacts
+        id: collect
+        run: |
+          BUNDLE="apps/desktop/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle"
+          APPIMAGE_SIG=$(find "$BUNDLE/appimage" -name '*.AppImage.sig' 2>/dev/null | head -1)
+          APPIMAGE=$(find "$BUNDLE/appimage" -name '*.AppImage' ! -name '*.sig' 2>/dev/null | head -1)
+
+          if [ -n "$APPIMAGE_SIG" ] && [ -n "$APPIMAGE" ]; then
+            echo "sig=$(cat "$APPIMAGE_SIG")" >> $GITHUB_OUTPUT
+            echo "url=$(basename "$APPIMAGE")" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-linux
+          path: |
+            apps/desktop/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/**/*.deb
+            apps/desktop/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/**/*.rpm
+            apps/desktop/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/**/*.AppImage
+            apps/desktop/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/**/*.sig
+          if-no-files-found: warn
+
+    outputs:
+      sig: ${{ steps.collect.outputs.sig }}
+      url: ${{ steps.collect.outputs.url }}
+
+  # ──────────────────────────────────────────────
+  # Publish: generate latest.json & upload to release
+  # ──────────────────────────────────────────────
+  publish:
+    needs: [build-windows, build-macos, build-linux]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') || inputs.release_tag != ''
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determine tag
+        id: tag
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${{ inputs.release_tag }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Generate latest.json
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          WIN_SIG: ${{ needs.build-windows.outputs.sig }}
+          WIN_URL: ${{ needs.build-windows.outputs.url }}
+          MAC_SIG: ${{ needs.build-macos.outputs.sig }}
+          MAC_URL: ${{ needs.build-macos.outputs.url }}
+          LIN_SIG: ${{ needs.build-linux.outputs.sig }}
+          LIN_URL: ${{ needs.build-linux.outputs.url }}
+        run: |
+          VERSION="${TAG#v}"
+          PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          BASE_URL="https://github.com/delibae/claude-prism/releases/download/$TAG"
+
+          node -e "
+            const platforms = {};
+            if (process.env.MAC_SIG && process.env.MAC_URL)
+              platforms['darwin-aarch64'] = { signature: process.env.MAC_SIG, url: process.env.BASE_URL + '/' + process.env.MAC_URL };
+            if (process.env.LIN_SIG && process.env.LIN_URL)
+              platforms['linux-x86_64'] = { signature: process.env.LIN_SIG, url: process.env.BASE_URL + '/' + process.env.LIN_URL };
+            if (process.env.WIN_SIG && process.env.WIN_URL)
+              platforms['windows-x86_64'] = { signature: process.env.WIN_SIG, url: process.env.BASE_URL + '/' + process.env.WIN_URL };
+
+            const data = {
+              version: '$VERSION',
+              notes: 'ClaudePrism $TAG',
+              pub_date: '$PUB_DATE',
+              platforms
+            };
+            require('fs').writeFileSync('latest.json', JSON.stringify(data, null, 2));
+            console.log(JSON.stringify(data, null, 2));
+          "
+
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          gh release view "$TAG" > /dev/null 2>&1 || \
+            gh release create "$TAG" --title "ClaudePrism $TAG" --generate-notes --draft
+
+      - name: Upload all assets to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+
+          # Upload latest.json
+          gh release upload "$TAG" latest.json --clobber
+
+          # Upload all platform artifacts
+          find artifacts -type f \( \
+            -name "*.dmg" -o -name "*.app.tar.gz" -o \
+            -name "*.exe" -o -name "*.msi" -o -name "*.nsis.zip" -o \
+            -name "*.deb" -o -name "*.rpm" -o -name "*.AppImage" \
+          \) | while read -r file; do
+            echo "Uploading: $file"
+            gh release upload "$TAG" "$file" --clobber
+          done
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          gh release edit "$TAG" --draft=false

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-prism/desktop",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "scripts": {
@@ -31,6 +31,7 @@
     "@tauri-apps/plugin-fs": "^2.3.0",
     "@tauri-apps/plugin-process": "^2.2.2",
     "@tauri-apps/plugin-shell": "^2.2.2",
+    "@tauri-apps/plugin-updater": "~2.10.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-prism-desktop"
-version = "1.0.0"
+version = "1.0.1"
 description = "AI-powered LaTeX writing workspace"
 edition = "2021"
 
@@ -51,3 +51,6 @@ tempfile = "3"
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSImage", "NSRunningApplication"] }
 objc2-foundation = { version = "0.3", features = ["NSData"] }
+
+[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
+tauri-plugin-updater = "2"

--- a/apps/desktop/src-tauri/capabilities/desktop.json
+++ b/apps/desktop/src-tauri/capabilities/desktop.json
@@ -1,0 +1,14 @@
+{
+  "identifier": "desktop-capability",
+  "platforms": [
+    "macOS",
+    "windows",
+    "linux"
+  ],
+  "windows": [
+    "main"
+  ],
+  "permissions": [
+    "updater:default"
+  ]
+}

--- a/apps/desktop/src-tauri/src/claude.rs
+++ b/apps/desktop/src-tauri/src/claude.rs
@@ -131,7 +131,11 @@ fn find_claude_binary() -> Result<String, String> {
         #[cfg(target_os = "windows")]
         let user_paths = vec![
             home.join(".claude").join("local").join("claude.exe"),
-            home.join("AppData").join("Local").join("Programs").join("claude").join("claude.exe"),
+            home.join("AppData")
+                .join("Local")
+                .join("Programs")
+                .join("claude")
+                .join("claude.exe"),
         ];
 
         for path in &user_paths {
@@ -202,7 +206,10 @@ fn strip_ansi(s: &str) -> Cow<'_, str> {
 /// Returns a borrowed reference when no nul bytes are present (zero-alloc fast path).
 fn strip_nul(s: &str) -> Cow<'_, str> {
     if s.contains('\0') {
-        eprintln!("[claude-spawn] stripped {} nul byte(s) from input", s.matches('\0').count());
+        eprintln!(
+            "[claude-spawn] stripped {} nul byte(s) from input",
+            s.matches('\0').count()
+        );
         Cow::Owned(s.replace('\0', ""))
     } else {
         Cow::Borrowed(s)
@@ -220,7 +227,9 @@ fn resolve_cmd_to_node(program: &str) -> (String, Vec<String>) {
     }
     // Try to find the JS entry point next to the .cmd file
     // npm .cmd wrappers invoke: node "<dir>\node_modules\<pkg>\cli.js" %*
-    let cmd_dir = std::path::Path::new(program).parent().unwrap_or(std::path::Path::new("."));
+    let cmd_dir = std::path::Path::new(program)
+        .parent()
+        .unwrap_or(std::path::Path::new("."));
     let cli_js = cmd_dir
         .join("node_modules")
         .join("@anthropic-ai")
@@ -239,7 +248,10 @@ fn resolve_cmd_to_node(program: &str) -> (String, Vec<String>) {
         return (node, vec![cli_js.to_string_lossy().to_string()]);
     }
     // Fallback: use cmd.exe /C (may have issues with special chars in args)
-    ("cmd.exe".to_string(), vec!["/C".to_string(), program.to_string()])
+    (
+        "cmd.exe".to_string(),
+        vec!["/C".to_string(), program.to_string()],
+    )
 }
 
 /// Create a std::process::Command that handles .cmd/.bat files on Windows.
@@ -260,7 +272,12 @@ fn new_sync_command(program: &str) -> std::process::Command {
 }
 
 /// Create a tokio Command with appropriate environment variables.
-fn create_command(program: &str, args: Vec<String>, cwd: &str, effort_level: Option<&str>) -> Command {
+fn create_command(
+    program: &str,
+    args: Vec<String>,
+    cwd: &str,
+    effort_level: Option<&str>,
+) -> Command {
     let clean_program = strip_nul(program);
     let clean_args: Vec<Cow<str>> = args.iter().map(|a| strip_nul(a)).collect();
     let clean_cwd = strip_nul(cwd);
@@ -364,18 +381,26 @@ async fn spawn_claude_process(
     let process_key = format!("{}:{}", window_label, tab_id);
 
     // Spawn the process
-    let mut child = cmd
-        .spawn()
-        .map_err(|e| {
-            eprintln!("[claude-spawn] Failed to spawn process for tab {}: {}", tab_id, e);
-            format!("Failed to spawn Claude process: {}. Is Claude Code CLI installed?", e)
-        })?;
+    let mut child = cmd.spawn().map_err(|e| {
+        eprintln!(
+            "[claude-spawn] Failed to spawn process for tab {}: {}",
+            tab_id, e
+        );
+        format!(
+            "Failed to spawn Claude process: {}. Is Claude Code CLI installed?",
+            e
+        )
+    })?;
 
     let stdout = child.stdout.take().ok_or("Failed to capture stdout")?;
     let stderr = child.stderr.take().ok_or("Failed to capture stderr")?;
 
     // Get a clone of the process state Arc before any moves
-    let process_arc = window.state::<ClaudeProcessState>().inner().processes.clone();
+    let process_arc = window
+        .state::<ClaudeProcessState>()
+        .inner()
+        .processes
+        .clone();
 
     // Store the child process in state (kill any existing process for this tab)
     {
@@ -408,7 +433,15 @@ async fn spawn_claude_process(
             if let Ok(msg) = serde_json::from_str::<serde_json::Value>(&line) {
                 let msg_type = msg.get("type").and_then(|v| v.as_str()).unwrap_or("?");
                 let msg_sub = msg.get("subtype").and_then(|v| v.as_str()).unwrap_or("");
-                eprintln!("[claude-stdout] [{}] +{:.1}s #{} type={} sub={} len={}", tab_id_stdout, elapsed, line_count, msg_type, msg_sub, line.len());
+                eprintln!(
+                    "[claude-stdout] [{}] +{:.1}s #{} type={} sub={} len={}",
+                    tab_id_stdout,
+                    elapsed,
+                    line_count,
+                    msg_type,
+                    msg_sub,
+                    line.len()
+                );
 
                 if msg.get("type").and_then(|v| v.as_str()) == Some("system")
                     && msg.get("subtype").and_then(|v| v.as_str()) == Some("init")
@@ -422,12 +455,20 @@ async fn spawn_claude_process(
             }
 
             // Emit output event to this window with tab_id
-            let _ = win_stdout.emit("claude-output", ClaudeOutputEvent {
-                tab_id: tab_id_stdout.clone(),
-                data: line,
-            });
+            let _ = win_stdout.emit(
+                "claude-output",
+                ClaudeOutputEvent {
+                    tab_id: tab_id_stdout.clone(),
+                    data: line,
+                },
+            );
         }
-        eprintln!("[claude-stdout] [{}] stream ended after {} lines ({:.1}s)", tab_id_stdout, line_count, start_time.elapsed().as_secs_f64());
+        eprintln!(
+            "[claude-stdout] [{}] stream ended after {} lines ({:.1}s)",
+            tab_id_stdout,
+            line_count,
+            start_time.elapsed().as_secs_f64()
+        );
     });
 
     // Spawn stderr streaming task — emit only to the originating window
@@ -436,11 +477,19 @@ async fn spawn_claude_process(
     let stderr_task = tokio::spawn(async move {
         let mut lines = stderr_reader.lines();
         while let Ok(Some(line)) = lines.next_line().await {
-            eprintln!("[claude-stderr] [{}] +{:.1}s {}", tab_id_stderr, start_time.elapsed().as_secs_f64(), &line[..line.len().min(200)]);
-            let _ = win_stderr.emit("claude-error", ClaudeErrorEvent {
-                tab_id: tab_id_stderr.clone(),
-                data: line,
-            });
+            eprintln!(
+                "[claude-stderr] [{}] +{:.1}s {}",
+                tab_id_stderr,
+                start_time.elapsed().as_secs_f64(),
+                &line[..line.len().min(200)]
+            );
+            let _ = win_stderr.emit(
+                "claude-error",
+                ClaudeErrorEvent {
+                    tab_id: tab_id_stderr.clone(),
+                    data: line,
+                },
+            );
         }
     });
 
@@ -459,25 +508,42 @@ async fn spawn_claude_process(
         let success = if let Some(mut child) = processes.remove(&process_key_wait) {
             match child.wait().await {
                 Ok(status) => {
-                    eprintln!("[claude-process] [{}] exited with status={} ({:.1}s)", tab_id_wait, status, start_time.elapsed().as_secs_f64());
+                    eprintln!(
+                        "[claude-process] [{}] exited with status={} ({:.1}s)",
+                        tab_id_wait,
+                        status,
+                        start_time.elapsed().as_secs_f64()
+                    );
                     status.success()
                 }
                 Err(e) => {
-                    eprintln!("[claude-process] [{}] wait error: {} ({:.1}s)", tab_id_wait, e, start_time.elapsed().as_secs_f64());
+                    eprintln!(
+                        "[claude-process] [{}] wait error: {} ({:.1}s)",
+                        tab_id_wait,
+                        e,
+                        start_time.elapsed().as_secs_f64()
+                    );
                     false
                 }
             }
         } else {
-            eprintln!("[claude-process] [{}] no child found in map ({:.1}s)", tab_id_wait, start_time.elapsed().as_secs_f64());
+            eprintln!(
+                "[claude-process] [{}] no child found in map ({:.1}s)",
+                tab_id_wait,
+                start_time.elapsed().as_secs_f64()
+            );
             false
         };
         drop(processes);
 
         // Emit completion event to this window with tab_id
-        let _ = win_wait.emit("claude-complete", ClaudeCompleteEvent {
-            tab_id: tab_id_wait,
-            success,
-        });
+        let _ = win_wait.emit(
+            "claude-complete",
+            ClaudeCompleteEvent {
+                tab_id: tab_id_wait,
+                success,
+            },
+        );
     });
 
     Ok(())
@@ -558,9 +624,7 @@ pub async fn check_claude_status() -> Result<ClaudeStatus, String> {
     };
 
     // Verify binary actually works by running --version
-    let version_output = new_sync_command(&binary_path)
-        .arg("--version")
-        .output();
+    let version_output = new_sync_command(&binary_path).arg("--version").output();
 
     let version = match version_output {
         Ok(output) if output.status.success() => {
@@ -589,16 +653,13 @@ pub async fn check_claude_status() -> Result<ClaudeStatus, String> {
         Ok(output) if output.status.success() => {
             let stdout = String::from_utf8_lossy(&output.stdout).to_string();
             // Parse for email — claude auth status outputs account info
-            let email = stdout
-                .lines()
-                .find(|line| line.contains('@'))
-                .map(|line| {
-                    // Extract email-like substring
-                    line.split_whitespace()
-                        .find(|word| word.contains('@'))
-                        .unwrap_or(line.trim())
-                        .to_string()
-                });
+            let email = stdout.lines().find(|line| line.contains('@')).map(|line| {
+                // Extract email-like substring
+                line.split_whitespace()
+                    .find(|word| word.contains('@'))
+                    .unwrap_or(line.trim())
+                    .to_string()
+            });
             (true, email)
         }
         _ => (false, None),
@@ -667,7 +728,9 @@ fn build_elevation_script(dirs: &[PathBuf], user: &str, local_dir: &std::path::P
         .join(" ");
     format!(
         "mkdir -p {} && chown -R {} '{}'",
-        dirs_list, user, local_dir.display()
+        dirs_list,
+        user,
+        local_dir.display()
     )
 }
 
@@ -738,7 +801,13 @@ pub async fn install_claude_cli(window: WebviewWindow) -> Result<(), String> {
         use std::os::windows::process::CommandExt;
         let mut c = tokio::process::Command::new("powershell");
         c.creation_flags(CREATE_NO_WINDOW);
-        c.args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", "irm https://claude.ai/install.ps1 | iex"]);
+        c.args([
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            "irm https://claude.ai/install.ps1 | iex",
+        ]);
         c
     };
     cmd.stdout(std::process::Stdio::piped());
@@ -828,13 +897,10 @@ pub async fn install_claude_cli(window: WebviewWindow) -> Result<(), String> {
 
 #[tauri::command]
 pub async fn login_claude(window: WebviewWindow) -> Result<(), String> {
-    let binary_path = find_claude_binary()
-        .map_err(|e| format!("Claude CLI not found: {}", e))?;
+    let binary_path = find_claude_binary().map_err(|e| format!("Claude CLI not found: {}", e))?;
 
     // Verify it actually exists
-    let version_check = new_sync_command(&binary_path)
-        .arg("--version")
-        .output();
+    let version_check = new_sync_command(&binary_path).arg("--version").output();
 
     if !version_check.as_ref().is_ok_and(|o| o.status.success()) {
         return Err("Claude CLI is not properly installed".to_string());
@@ -969,10 +1035,7 @@ pub async fn execute_claude_code(
 ) -> Result<(), String> {
     let claude_path = find_claude_binary()?;
 
-    let mut args = vec![
-        "-p".to_string(),
-        prompt,
-    ];
+    let mut args = vec!["-p".to_string(), prompt];
     if let Some(m) = model {
         args.push("--model".to_string());
         args.push(m);
@@ -994,11 +1057,7 @@ pub async fn continue_claude_code(
 ) -> Result<(), String> {
     let claude_path = find_claude_binary()?;
 
-    let mut args = vec![
-        "-c".to_string(),
-        "-p".to_string(),
-        prompt,
-    ];
+    let mut args = vec!["-c".to_string(), "-p".to_string(), prompt];
     if let Some(m) = model {
         args.push("--model".to_string());
         args.push(m);
@@ -1021,12 +1080,7 @@ pub async fn resume_claude_code(
 ) -> Result<(), String> {
     let claude_path = find_claude_binary()?;
 
-    let mut args = vec![
-        "--resume".to_string(),
-        session_id,
-        "-p".to_string(),
-        prompt,
-    ];
+    let mut args = vec!["--resume".to_string(), session_id, "-p".to_string(), prompt];
     if let Some(m) = model {
         args.push("--model".to_string());
         args.push(m);
@@ -1038,20 +1092,20 @@ pub async fn resume_claude_code(
 }
 
 #[tauri::command]
-pub async fn cancel_claude_execution(
-    window: WebviewWindow,
-    tab_id: String,
-) -> Result<(), String> {
+pub async fn cancel_claude_execution(window: WebviewWindow, tab_id: String) -> Result<(), String> {
     let window_label = window.label().to_string();
     let process_key = format!("{}:{}", window_label, tab_id);
     let claude_state = window.state::<ClaudeProcessState>();
     let mut processes = claude_state.processes.lock().await;
     if let Some(mut child) = processes.remove(&process_key) {
         let _ = child.kill().await;
-        let _ = window.emit("claude-complete", ClaudeCompleteEvent {
-            tab_id,
-            success: false,
-        });
+        let _ = window.emit(
+            "claude-complete",
+            ClaudeCompleteEvent {
+                tab_id,
+                success: false,
+            },
+        );
     }
     Ok(())
 }
@@ -1086,15 +1140,17 @@ pub struct ClaudeSessionInfo {
 /// Claude Code encodes paths by replacing all non-alphanumeric characters with '-'.
 /// e.g. "/Users/dev/my_project" → "-Users-dev-my-project"
 fn get_sessions_dir(project_path: &str) -> Result<PathBuf, String> {
-    let home = dirs::home_dir()
-        .ok_or("Could not determine home directory")?;
+    let home = dirs::home_dir().ok_or("Could not determine home directory")?;
 
     let encoded: String = project_path
         .chars()
         .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
         .collect();
 
-    eprintln!("[session] project_path={} encoded={}", project_path, encoded);
+    eprintln!(
+        "[session] project_path={} encoded={}",
+        project_path, encoded
+    );
 
     Ok(home.join(".claude").join("projects").join(&encoded))
 }
@@ -1166,7 +1222,10 @@ fn extract_first_user_message(path: &PathBuf) -> (Option<String>, Option<String>
             Some(v) => v,
             None => continue,
         };
-        let timestamp = msg.get("timestamp").and_then(|v| v.as_str()).map(|s| s.to_string());
+        let timestamp = msg
+            .get("timestamp")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
 
         // Case 1: content is a plain string (Claude Code stored JSONL format)
         if let Some(text) = content_val.as_str() {
@@ -1193,12 +1252,17 @@ fn extract_first_user_message(path: &PathBuf) -> (Option<String>, Option<String>
 }
 
 #[tauri::command]
-pub async fn list_claude_sessions(
-    project_path: String,
-) -> Result<Vec<ClaudeSessionInfo>, String> {
-    eprintln!("[session] list_claude_sessions called with project_path={}", project_path);
+pub async fn list_claude_sessions(project_path: String) -> Result<Vec<ClaudeSessionInfo>, String> {
+    eprintln!(
+        "[session] list_claude_sessions called with project_path={}",
+        project_path
+    );
     let sessions_dir = get_sessions_dir(&project_path)?;
-    eprintln!("[session] sessions_dir={:?} exists={}", sessions_dir, sessions_dir.exists());
+    eprintln!(
+        "[session] sessions_dir={:?} exists={}",
+        sessions_dir,
+        sessions_dir.exists()
+    );
 
     if !sessions_dir.exists() {
         eprintln!("[session] sessions_dir does not exist, returning empty");
@@ -1228,7 +1292,11 @@ pub async fn list_claude_sessions(
         let metadata = std::fs::metadata(&path).ok();
         let modified = metadata
             .and_then(|m| m.modified().ok())
-            .map(|t| t.duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs() as i64)
+            .map(|t| {
+                t.duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs() as i64
+            })
             .unwrap_or(0);
 
         let (first_message, _timestamp) = extract_first_user_message(&path);
@@ -1245,7 +1313,10 @@ pub async fn list_claude_sessions(
 
     eprintln!("[session] found {} sessions", sessions.len());
     for s in &sessions {
-        eprintln!("[session]   id={} title={} modified={}", s.session_id, s.title, s.last_modified);
+        eprintln!(
+            "[session]   id={} title={} modified={}",
+            s.session_id, s.title, s.last_modified
+        );
     }
 
     Ok(sessions)
@@ -1257,10 +1328,17 @@ pub async fn load_session_history(
     project_path: String,
     session_id: String,
 ) -> Result<Vec<serde_json::Value>, String> {
-    eprintln!("[session] load_session_history called: session_id={} project_path={}", session_id, project_path);
+    eprintln!(
+        "[session] load_session_history called: session_id={} project_path={}",
+        session_id, project_path
+    );
     let sessions_dir = get_sessions_dir(&project_path)?;
     let session_path = sessions_dir.join(format!("{}.jsonl", session_id));
-    eprintln!("[session] session_path={:?} exists={}", session_path, session_path.exists());
+    eprintln!(
+        "[session] session_path={:?} exists={}",
+        session_path,
+        session_path.exists()
+    );
 
     if !session_path.exists() {
         return Err(format!("Session file not found: {}", session_id));
@@ -1279,7 +1357,11 @@ pub async fn load_session_history(
         }
     }
 
-    eprintln!("[session] loaded {} messages from session {}", messages.len(), session_id);
+    eprintln!(
+        "[session] loaded {} messages from session {}",
+        messages.len(),
+        session_id
+    );
 
     Ok(messages)
 }
@@ -1294,10 +1376,7 @@ pub struct ShellCommandResult {
 }
 
 #[tauri::command]
-pub async fn run_shell_command(
-    command: String,
-    cwd: String,
-) -> Result<ShellCommandResult, String> {
+pub async fn run_shell_command(command: String, cwd: String) -> Result<ShellCommandResult, String> {
     #[cfg(not(target_os = "windows"))]
     let (shell, args) = ("sh", vec!["-c".to_string(), command]);
     #[cfg(target_os = "windows")]
@@ -1333,11 +1412,14 @@ pub async fn get_claude_fast_mode() -> Result<bool, String> {
     if !path.exists() {
         return Ok(false);
     }
-    let content = std::fs::read_to_string(&path)
-        .map_err(|e| format!("Failed to read settings: {}", e))?;
-    let settings: serde_json::Value = serde_json::from_str(&content)
-        .unwrap_or(serde_json::json!({}));
-    Ok(settings.get("fastMode").and_then(|v| v.as_bool()).unwrap_or(false))
+    let content =
+        std::fs::read_to_string(&path).map_err(|e| format!("Failed to read settings: {}", e))?;
+    let settings: serde_json::Value =
+        serde_json::from_str(&content).unwrap_or(serde_json::json!({}));
+    Ok(settings
+        .get("fastMode")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false))
 }
 
 #[tauri::command]
@@ -1371,8 +1453,7 @@ pub async fn set_claude_fast_mode(enabled: bool) -> Result<(), String> {
     // Write back
     let content = serde_json::to_string_pretty(&settings)
         .map_err(|e| format!("Failed to serialize settings: {}", e))?;
-    std::fs::write(&path, content)
-        .map_err(|e| format!("Failed to write settings: {}", e))?;
+    std::fs::write(&path, content).map_err(|e| format!("Failed to write settings: {}", e))?;
 
     Ok(())
 }
@@ -1428,7 +1509,10 @@ mod tests {
     #[test]
     fn test_clean_user_message_title_skips_command_tags() {
         assert_eq!(clean_user_message_title("<command-name>test"), None);
-        assert_eq!(clean_user_message_title("<local-command-stdout>output"), None);
+        assert_eq!(
+            clean_user_message_title("<local-command-stdout>output"),
+            None
+        );
     }
 
     #[test]
@@ -1474,7 +1558,10 @@ mod tests {
     #[test]
     fn test_common_claude_args_system_prompt_mentions_latex() {
         let args = common_claude_args();
-        let prompt_idx = args.iter().position(|a| a == "--append-system-prompt").unwrap();
+        let prompt_idx = args
+            .iter()
+            .position(|a| a == "--append-system-prompt")
+            .unwrap();
         let prompt = &args[prompt_idx + 1];
         assert!(prompt.contains("LaTeX"));
     }
@@ -1651,10 +1738,7 @@ mod tests {
     #[test]
     fn test_try_create_dirs_succeeds_in_temp() {
         let tmp = tempfile::tempdir().unwrap();
-        let dirs = vec![
-            tmp.path().join("a").join("b"),
-            tmp.path().join("c"),
-        ];
+        let dirs = vec![tmp.path().join("a").join("b"), tmp.path().join("c")];
         assert!(try_create_dirs(&dirs));
         assert!(dirs[0].exists());
         assert!(dirs[1].exists());
@@ -1701,7 +1785,11 @@ mod tests {
             PathBuf::from("/Users/test/.local/bin"),
             PathBuf::from("/Users/test/.claude"),
         ];
-        let script = build_elevation_script(&dirs, "testuser", std::path::Path::new("/Users/test/.local"));
+        let script = build_elevation_script(
+            &dirs,
+            "testuser",
+            std::path::Path::new("/Users/test/.local"),
+        );
         assert!(script.contains("mkdir -p"));
         assert!(script.contains("'/Users/test/.local/bin'"));
         assert!(script.contains("'/Users/test/.claude'"));
@@ -1713,7 +1801,11 @@ mod tests {
     #[test]
     fn test_build_elevation_script_handles_spaces_in_path() {
         let dirs = vec![PathBuf::from("/Users/my user/.local/bin")];
-        let script = build_elevation_script(&dirs, "myuser", std::path::Path::new("/Users/my user/.local"));
+        let script = build_elevation_script(
+            &dirs,
+            "myuser",
+            std::path::Path::new("/Users/my user/.local"),
+        );
         // Paths are single-quoted to handle spaces
         assert!(script.contains("'/Users/my user/.local/bin'"));
         assert!(script.contains("'/Users/my user/.local'"));

--- a/apps/desktop/src-tauri/src/history.rs
+++ b/apps/desktop/src-tauri/src/history.rs
@@ -1,6 +1,4 @@
-use git2::{
-    DiffOptions, IndexAddOption, Oid, Repository, RepositoryInitOptions, Signature, Sort,
-};
+use git2::{DiffOptions, IndexAddOption, Oid, Repository, RepositoryInitOptions, Signature, Sort};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::fs;
@@ -49,10 +47,11 @@ fn tag_map(repo: &Repository) -> HashMap<Oid, Vec<String>> {
     if let Ok(tags) = repo.tag_names(None) {
         for tag_name in tags.iter().flatten() {
             if let Ok(reference) = repo.revparse_single(tag_name) {
-                let oid = reference.peel_to_commit().map(|c| c.id()).unwrap_or(reference.id());
-                map.entry(oid)
-                    .or_default()
-                    .push(tag_name.to_string());
+                let oid = reference
+                    .peel_to_commit()
+                    .map(|c| c.id())
+                    .unwrap_or(reference.id());
+                map.entry(oid).or_default().push(tag_name.to_string());
             }
         }
     }
@@ -107,10 +106,7 @@ Thumbs.db
     }
     // Configure the repo to use this excludes file
     if let Ok(mut config) = repo.config() {
-        let _ = config.set_str(
-            "core.excludesFile",
-            &excludes_path.to_string_lossy(),
-        );
+        let _ = config.set_str("core.excludesFile", &excludes_path.to_string_lossy());
     }
 }
 
@@ -122,8 +118,8 @@ pub fn history_init(project_root: String) -> Result<(), String> {
 
     if git_dir.exists() {
         // Already initialized — verify and ensure excludes
-        let repo = Repository::open(&git_dir)
-            .map_err(|e| format!("Corrupt history repo: {}", e))?;
+        let repo =
+            Repository::open(&git_dir).map_err(|e| format!("Corrupt history repo: {}", e))?;
         ensure_excludes(&project_root, &repo);
         return Ok(());
     }
@@ -166,14 +162,24 @@ pub fn history_init(project_root: String) -> Result<(), String> {
         .map_err(|e| format!("Failed to find tree: {}", e))?;
 
     let sig = default_signature()?;
-    repo.commit(Some("HEAD"), &sig, &sig, "[init] Project opened", &tree, &[])
-        .map_err(|e| format!("Failed to create initial commit: {}", e))?;
+    repo.commit(
+        Some("HEAD"),
+        &sig,
+        &sig,
+        "[init] Project opened",
+        &tree,
+        &[],
+    )
+    .map_err(|e| format!("Failed to create initial commit: {}", e))?;
 
     Ok(())
 }
 
 #[tauri::command]
-pub fn history_snapshot(project_root: String, message: String) -> Result<Option<SnapshotInfo>, String> {
+pub fn history_snapshot(
+    project_root: String,
+    message: String,
+) -> Result<Option<SnapshotInfo>, String> {
     let repo = open_repo(&project_root)?;
 
     let mut index = repo
@@ -219,10 +225,7 @@ pub fn history_snapshot(project_root: String, message: String) -> Result<Option<
         .map_err(|e| format!("Failed to find tree: {}", e))?;
 
     let sig = default_signature()?;
-    let parent = repo
-        .head()
-        .ok()
-        .and_then(|h| h.peel_to_commit().ok());
+    let parent = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
     let parents: Vec<&git2::Commit> = parent.iter().collect();
 
     let oid = repo
@@ -236,7 +239,9 @@ pub fn history_snapshot(project_root: String, message: String) -> Result<Option<
             .map(|d| {
                 d.deltas()
                     .filter_map(|delta| {
-                        delta.new_file().path()
+                        delta
+                            .new_file()
+                            .path()
                             .or_else(|| delta.old_file().path())
                             .map(|p| p.to_string_lossy().to_string())
                     })
@@ -268,8 +273,12 @@ pub fn history_list(
     let mut revwalk = repo
         .revwalk()
         .map_err(|e| format!("Failed to create revwalk: {}", e))?;
-    revwalk.push_head().map_err(|e| format!("Failed to push HEAD: {}", e))?;
-    revwalk.set_sorting(Sort::TIME).map_err(|e| format!("Sort error: {}", e))?;
+    revwalk
+        .push_head()
+        .map_err(|e| format!("Failed to push HEAD: {}", e))?;
+    revwalk
+        .set_sorting(Sort::TIME)
+        .map_err(|e| format!("Sort error: {}", e))?;
 
     let mut snapshots = Vec::new();
     let mut count = 0u32;
@@ -301,7 +310,9 @@ pub fn history_list(
                 .map(|d| {
                     d.deltas()
                         .filter_map(|delta| {
-                            delta.new_file().path()
+                            delta
+                                .new_file()
+                                .path()
                                 .or_else(|| delta.old_file().path())
                                 .map(|p| p.to_string_lossy().to_string())
                         })
@@ -347,9 +358,7 @@ pub fn history_diff(
     let from_tree = from_commit
         .tree()
         .map_err(|e| format!("Tree error: {}", e))?;
-    let to_tree = to_commit
-        .tree()
-        .map_err(|e| format!("Tree error: {}", e))?;
+    let to_tree = to_commit.tree().map_err(|e| format!("Tree error: {}", e))?;
 
     let mut diff_opts = DiffOptions::new();
     let diff = repo
@@ -421,9 +430,7 @@ pub fn history_file_at(
     let commit = repo
         .find_commit(oid)
         .map_err(|e| format!("Commit not found: {}", e))?;
-    let tree = commit
-        .tree()
-        .map_err(|e| format!("Tree error: {}", e))?;
+    let tree = commit.tree().map_err(|e| format!("Tree error: {}", e))?;
     let entry = tree
         .get_path(Path::new(&file_path))
         .map_err(|e| format!("File not found in snapshot: {}", e))?;
@@ -439,18 +446,13 @@ pub fn history_file_at(
 }
 
 #[tauri::command]
-pub fn history_restore(
-    project_root: String,
-    snapshot_id: String,
-) -> Result<SnapshotInfo, String> {
+pub fn history_restore(project_root: String, snapshot_id: String) -> Result<SnapshotInfo, String> {
     let repo = open_repo(&project_root)?;
     let oid = Oid::from_str(&snapshot_id).map_err(|e| format!("Invalid snapshot_id: {}", e))?;
     let commit = repo
         .find_commit(oid)
         .map_err(|e| format!("Commit not found: {}", e))?;
-    let tree = commit
-        .tree()
-        .map_err(|e| format!("Tree error: {}", e))?;
+    let tree = commit.tree().map_err(|e| format!("Tree error: {}", e))?;
 
     // Checkout the tree to working directory
     repo.checkout_tree(
@@ -460,9 +462,7 @@ pub fn history_restore(
     .map_err(|e| format!("Checkout failed: {}", e))?;
 
     // Create a new "restore" commit on HEAD (not moving HEAD to old commit)
-    let mut index = repo
-        .index()
-        .map_err(|e| format!("Index error: {}", e))?;
+    let mut index = repo.index().map_err(|e| format!("Index error: {}", e))?;
     index
         .add_all(["*"].iter(), IndexAddOption::DEFAULT, None)
         .map_err(|e| format!("Add error: {}", e))?;
@@ -476,10 +476,7 @@ pub fn history_restore(
         .map_err(|e| format!("Find tree error: {}", e))?;
 
     let sig = default_signature()?;
-    let head_commit = repo
-        .head()
-        .ok()
-        .and_then(|h| h.peel_to_commit().ok());
+    let head_commit = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
     let parents: Vec<&git2::Commit> = head_commit.iter().collect();
 
     let short_id = &snapshot_id[..8.min(snapshot_id.len())];
@@ -687,7 +684,9 @@ mod tests {
         history_init(r.clone()).unwrap();
 
         fs::write(dir.path().join("main.tex"), "new content").unwrap();
-        let snap = history_snapshot(r.clone(), "update".into()).unwrap().unwrap();
+        let snap = history_snapshot(r.clone(), "update".into())
+            .unwrap()
+            .unwrap();
 
         let list = history_list(r.clone(), 10, 0).unwrap();
         let from_id = list[1].id.clone(); // init
@@ -708,7 +707,9 @@ mod tests {
         history_init(r.clone()).unwrap();
 
         fs::write(dir.path().join("b.tex"), "new file").unwrap();
-        let snap = history_snapshot(r.clone(), "add b".into()).unwrap().unwrap();
+        let snap = history_snapshot(r.clone(), "add b".into())
+            .unwrap()
+            .unwrap();
 
         let list = history_list(r.clone(), 10, 0).unwrap();
         let from_id = list[1].id.clone(); // init
@@ -847,7 +848,10 @@ mod tests {
         ensure_excludes(&r, &repo);
 
         let content = fs::read_to_string(&excludes_path).unwrap();
-        assert!(content.contains(".prism/"), "should migrate to include .prism/");
+        assert!(
+            content.contains(".prism/"),
+            "should migrate to include .prism/"
+        );
     }
 
     // ─── edge cases ───
@@ -861,7 +865,9 @@ mod tests {
         // Delete a file
         fs::remove_file(dir.path().join("b.tex")).unwrap();
 
-        let snap = history_snapshot(r.clone(), "delete b".into()).unwrap().unwrap();
+        let snap = history_snapshot(r.clone(), "delete b".into())
+            .unwrap()
+            .unwrap();
         assert!(!snap.changed_files.is_empty());
     }
 
@@ -875,7 +881,9 @@ mod tests {
         let init_id = list[0].id.clone();
 
         fs::remove_file(dir.path().join("b.tex")).unwrap();
-        let snap = history_snapshot(r.clone(), "delete b".into()).unwrap().unwrap();
+        let snap = history_snapshot(r.clone(), "delete b".into())
+            .unwrap()
+            .unwrap();
 
         let diffs = history_diff(r, init_id, snap.id).unwrap();
         let d = diffs.iter().find(|d| d.file_path == "b.tex").unwrap();

--- a/apps/desktop/src-tauri/src/latex.rs
+++ b/apps/desktop/src-tauri/src/latex.rs
@@ -143,10 +143,31 @@ fn sync_source_files(src: &Path, dst: &Path) -> std::io::Result<()> {
             sync_source_files(&src_path, &dst_path)?;
         } else {
             let ext = src_path.extension().and_then(|e| e.to_str()).unwrap_or("");
-            let is_artifact = matches!(ext, "aux" | "log" | "toc" | "lof" | "lot" | "out"
-                | "nav" | "snm" | "vrb" | "bbl" | "blg" | "fls" | "fdb_latexmk"
-                | "synctex" | "idx" | "ind" | "ilg" | "glo" | "gls" | "glg"
-                | "fmt" | "xdv");
+            let is_artifact = matches!(
+                ext,
+                "aux"
+                    | "log"
+                    | "toc"
+                    | "lof"
+                    | "lot"
+                    | "out"
+                    | "nav"
+                    | "snm"
+                    | "vrb"
+                    | "bbl"
+                    | "blg"
+                    | "fls"
+                    | "fdb_latexmk"
+                    | "synctex"
+                    | "idx"
+                    | "ind"
+                    | "ilg"
+                    | "glo"
+                    | "gls"
+                    | "glg"
+                    | "fmt"
+                    | "xdv"
+            );
             let is_synctex = src_path.to_string_lossy().ends_with(".synctex.gz");
             if !is_artifact && !is_synctex {
                 // Cloud storage (Dropbox/iCloud) may keep files as online-only
@@ -209,9 +230,12 @@ fn compile_with_tectonic(work_dir: &Path, main_file: &str) -> Result<(), String>
     let config = PersistentConfig::open(false)
         .map_err(|e| format!("Failed to open tectonic config: {}", e))?;
 
-    let bundle = config
-        .default_bundle(false, &mut status)
-        .map_err(|e| format!("Failed to load tectonic bundle (check network connection): {}", e))?;
+    let bundle = config.default_bundle(false, &mut status).map_err(|e| {
+        format!(
+            "Failed to load tectonic bundle (check network connection): {}",
+            e
+        )
+    })?;
 
     let format_cache = config
         .format_cache_path()
@@ -236,9 +260,7 @@ fn compile_with_tectonic(work_dir: &Path, main_file: &str) -> Result<(), String>
         .create(&mut status)
         .map_err(|e| format!("Failed to create tectonic session: {}", e))?;
 
-    session
-        .run(&mut status)
-        .map_err(|e| format!("{}", e))?;
+    session.run(&mut status).map_err(|e| format!("{}", e))?;
 
     Ok(())
 }
@@ -318,7 +340,10 @@ fn parse_synctex_data(
                 // Convert synctex internal units to PDF points (bp)
                 // 1 TeX pt = 65536 sp; 1 inch = 72.27 TeX pt = 72 PDF bp
                 let factor = unit * magnification / (1000.0 * 65536.0) * 72.0 / 72.27;
-                if let Some(node) = line.get(1..).and_then(|s| parse_synctex_node(s, factor, x_offset, y_offset)) {
+                if let Some(node) = line
+                    .get(1..)
+                    .and_then(|s| parse_synctex_node(s, factor, x_offset, y_offset))
+                {
                     nodes.push(node);
                 }
             }
@@ -350,12 +375,7 @@ fn parse_synctex_data(
 
 /// Parse a synctex node record (after stripping the type character).
 /// Format: `<tag>,<line>,<column>:<h>,<v>[:<W>,<H>,<D>]`
-fn parse_synctex_node(
-    s: &str,
-    factor: f64,
-    x_offset: f64,
-    y_offset: f64,
-) -> Option<SynctexNode> {
+fn parse_synctex_node(s: &str, factor: f64, x_offset: f64, y_offset: f64) -> Option<SynctexNode> {
     let colon_parts: Vec<&str> = s.splitn(4, ':').collect();
     if colon_parts.len() < 2 {
         return None;
@@ -443,7 +463,11 @@ pub async fn compile_latex(
     eprintln!(
         "[latex] +{:.0}ms {} ({})",
         t0.elapsed().as_millis(),
-        if is_reuse { "sync source files" } else { "full copy" },
+        if is_reuse {
+            "sync source files"
+        } else {
+            "full copy"
+        },
         if is_reuse { "reuse" } else { "first build" }
     );
 
@@ -663,7 +687,10 @@ mod tests {
     fn test_extract_error_lines_no_pages() {
         let log = "Some preamble\nNo pages of output.\nSome trailing";
         let result = extract_error_lines(log);
-        assert_eq!(result, "No pages of output. Add visible content to the document body.");
+        assert_eq!(
+            result,
+            "No pages of output. Add visible content to the document body."
+        );
     }
 
     #[test]
@@ -920,8 +947,15 @@ Postamble:
     fn test_extract_error_lines_real_errors_over_no_pages() {
         let log = "Some preamble\n! LaTeX Error: File `missing.sty' not found.\nNo pages of output.\nMore stuff";
         let result = extract_error_lines(log);
-        assert!(result.contains("LaTeX Error"), "real error should be shown, got: {}", result);
-        assert!(!result.contains("Add visible content"), "No pages fallback should NOT appear");
+        assert!(
+            result.contains("LaTeX Error"),
+            "real error should be shown, got: {}",
+            result
+        );
+        assert!(
+            !result.contains("Add visible content"),
+            "No pages fallback should NOT appear"
+        );
     }
 
     // --- has_real_errors ---
@@ -998,14 +1032,25 @@ Postamble:
         std::fs::create_dir_all(src.path().join("sub").join("deep")).unwrap();
         std::fs::write(src.path().join("top.tex"), "top").unwrap();
         std::fs::write(src.path().join("sub").join("mid.tex"), "mid").unwrap();
-        std::fs::write(src.path().join("sub").join("deep").join("bottom.tex"), "bottom").unwrap();
+        std::fs::write(
+            src.path().join("sub").join("deep").join("bottom.tex"),
+            "bottom",
+        )
+        .unwrap();
 
         copy_dir_recursive(src.path(), dst.path()).unwrap();
 
-        assert_eq!(std::fs::read_to_string(dst.path().join("top.tex")).unwrap(), "top");
-        assert_eq!(std::fs::read_to_string(dst.path().join("sub").join("mid.tex")).unwrap(), "mid");
         assert_eq!(
-            std::fs::read_to_string(dst.path().join("sub").join("deep").join("bottom.tex")).unwrap(),
+            std::fs::read_to_string(dst.path().join("top.tex")).unwrap(),
+            "top"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dst.path().join("sub").join("mid.tex")).unwrap(),
+            "mid"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dst.path().join("sub").join("deep").join("bottom.tex"))
+                .unwrap(),
             "bottom"
         );
     }
@@ -1052,9 +1097,18 @@ Postamble:
 
         sync_source_files(src.path(), dst.path()).unwrap();
 
-        assert_eq!(std::fs::read_to_string(dst.path().join("main.tex")).unwrap(), "doc");
-        assert_eq!(std::fs::read_to_string(dst.path().join("refs.bib")).unwrap(), "bib");
-        assert_eq!(std::fs::read_to_string(dst.path().join("style.sty")).unwrap(), "sty");
+        assert_eq!(
+            std::fs::read_to_string(dst.path().join("main.tex")).unwrap(),
+            "doc"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dst.path().join("refs.bib")).unwrap(),
+            "bib"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dst.path().join("style.sty")).unwrap(),
+            "sty"
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -24,10 +24,26 @@ struct EditorDef {
 }
 
 const KNOWN_EDITORS: &[EditorDef] = &[
-    EditorDef { id: "cursor", name: "Cursor", cli: "cursor" },
-    EditorDef { id: "vscode", name: "VS Code", cli: "code" },
-    EditorDef { id: "zed", name: "Zed", cli: "zed" },
-    EditorDef { id: "sublime", name: "Sublime Text", cli: "subl" },
+    EditorDef {
+        id: "cursor",
+        name: "Cursor",
+        cli: "cursor",
+    },
+    EditorDef {
+        id: "vscode",
+        name: "VS Code",
+        cli: "code",
+    },
+    EditorDef {
+        id: "zed",
+        name: "Zed",
+        cli: "zed",
+    },
+    EditorDef {
+        id: "sublime",
+        name: "Sublime Text",
+        cli: "subl",
+    },
 ];
 
 #[cfg(target_os = "macos")]
@@ -43,7 +59,10 @@ fn detect_editors() -> Vec<EditorInfo> {
     KNOWN_EDITORS
         .iter()
         .filter(|e| is_editor_installed(e))
-        .map(|e| EditorInfo { id: e.id.to_string(), name: e.name.to_string() })
+        .map(|e| EditorInfo {
+            id: e.id.to_string(),
+            name: e.name.to_string(),
+        })
         .collect()
 }
 
@@ -90,7 +109,8 @@ fn open_in_editor(
         }
     }
 
-    cmd.spawn().map_err(|e| format!("Failed to open {}: {}", editor.name, e))?;
+    cmd.spawn()
+        .map_err(|e| format!("Failed to open {}: {}", editor.name, e))?;
     Ok(())
 }
 
@@ -124,8 +144,8 @@ fn resolve_editor_cli(cli: &str) -> Result<String, String> {
 #[cfg(target_os = "macos")]
 fn set_macos_app_icon() {
     use objc2::{AnyThread, MainThreadMarker};
-    use objc2_foundation::NSData;
     use objc2_app_kit::{NSApplication, NSImage};
+    use objc2_foundation::NSData;
 
     let icon_bytes = include_bytes!("../icons/icon.png");
 
@@ -142,10 +162,13 @@ fn set_macos_app_icon() {
 
 #[tauri::command]
 fn create_new_window(app: tauri::AppHandle) -> Result<(), String> {
-    let label = format!("window-{}", std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis());
+    let label = format!(
+        "window-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+    );
 
     let mut builder = WebviewWindowBuilder::new(&app, &label, WebviewUrl::default())
         .title("ClaudePrism")
@@ -160,7 +183,9 @@ fn create_new_window(app: tauri::AppHandle) -> Result<(), String> {
             .traffic_light_position(tauri::LogicalPosition::new(12.0, 12.0));
     }
 
-    builder.build().map_err(|e| format!("Failed to create window: {}", e))?;
+    builder
+        .build()
+        .map_err(|e| format!("Failed to create window: {}", e))?;
 
     Ok(())
 }
@@ -225,6 +250,7 @@ pub fn run() {
 
     #[allow(clippy::expect_used)]
     let app = tauri::Builder::default()
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_shell::init())
@@ -232,9 +258,7 @@ pub fn run() {
         .manage(claude::ClaudeProcessState::default())
         .manage(latex::LatexCompilerState::default())
         .manage(zotero::ZoteroOAuthState::default())
-        .setup(|_app| {
-            Ok(())
-        })
+        .setup(|_app| Ok(()))
         .invoke_handler(tauri::generate_handler![
             create_new_window,
             detect_editors,
@@ -295,7 +319,11 @@ pub fn run() {
             tauri::RunEvent::Ready => {
                 set_macos_app_icon();
             }
-            tauri::RunEvent::WindowEvent { label, event: tauri::WindowEvent::Destroyed, .. } => {
+            tauri::RunEvent::WindowEvent {
+                label,
+                event: tauri::WindowEvent::Destroyed,
+                ..
+            } => {
                 // Kill Claude process associated with this window
                 let claude_state = app_handle.state::<claude::ClaudeProcessState>();
                 let label_clone = label.clone();

--- a/apps/desktop/src-tauri/src/skills.rs
+++ b/apps/desktop/src-tauri/src/skills.rs
@@ -52,7 +52,10 @@ pub struct SkillCategory {
 /// Returns the known scientific skill categories with metadata.
 fn skill_categories() -> Vec<SkillCategory> {
     fn s(name: &str, folder: &str) -> SkillEntry {
-        SkillEntry { name: name.into(), folder: folder.into() }
+        SkillEntry {
+            name: name.into(),
+            folder: folder.into(),
+        }
     }
 
     let mut cats = vec![
@@ -413,8 +416,8 @@ fn copy_skills(repo_dir: &Path, target_dir: &Path) -> Result<usize, String> {
     let mut count = 0;
 
     // Iterate through skill subdirectories
-    let entries = std::fs::read_dir(&src)
-        .map_err(|e| format!("Failed to read skills dir: {}", e))?;
+    let entries =
+        std::fs::read_dir(&src).map_err(|e| format!("Failed to read skills dir: {}", e))?;
 
     for entry in entries.flatten() {
         let entry_path = entry.path();
@@ -422,10 +425,7 @@ fn copy_skills(repo_dir: &Path, target_dir: &Path) -> Result<usize, String> {
             continue;
         }
 
-        let skill_name = entry
-            .file_name()
-            .to_string_lossy()
-            .to_string();
+        let skill_name = entry.file_name().to_string_lossy().to_string();
 
         let target_skill = target_dir.join(&skill_name);
         copy_dir_recursive(&entry_path, &target_skill)?;
@@ -466,10 +466,7 @@ fn parse_skill_md(skill_dir: &Path) -> Option<SkillInfo> {
     }
 
     let content = std::fs::read_to_string(&skill_md).ok()?;
-    let folder = skill_dir
-        .file_name()?
-        .to_string_lossy()
-        .to_string();
+    let folder = skill_dir.file_name()?.to_string_lossy().to_string();
 
     // Extract title from first # heading
     let name = content
@@ -492,11 +489,7 @@ fn parse_skill_md(skill_dir: &Path) -> Option<SkillInfo> {
         .collect::<String>();
 
     // Infer domain from folder name prefix (e.g., "bioinformatics-rna-seq" → "bioinformatics")
-    let domain = folder
-        .split('-')
-        .next()
-        .unwrap_or("general")
-        .to_string();
+    let domain = folder.split('-').next().unwrap_or("general").to_string();
 
     Some(SkillInfo {
         id: folder.clone(),
@@ -569,8 +562,13 @@ fn ensure_target_writable(target: &Path) -> Result<(), String> {
 
         // Verify writable
         let test_file = target.join(".prism_write_test");
-        std::fs::write(&test_file, "test")
-            .map_err(|e| format!("Directory {} still not writable after elevation: {}", target.display(), e))?;
+        std::fs::write(&test_file, "test").map_err(|e| {
+            format!(
+                "Directory {} still not writable after elevation: {}",
+                target.display(),
+                e
+            )
+        })?;
         let _ = std::fs::remove_file(&test_file);
     }
 
@@ -615,12 +613,11 @@ async fn install_skills_to(
             .unwrap_or_default()
             .as_millis()
     ));
-    std::fs::create_dir_all(&tmp_dir)
-        .map_err(|e| {
-            let msg = format!("Failed to create temp dir: {}", e);
-            emit_log(window, &msg);
-            msg
-        })?;
+    std::fs::create_dir_all(&tmp_dir).map_err(|e| {
+        let msg = format!("Failed to create temp dir: {}", e);
+        emit_log(window, &msg);
+        msg
+    })?;
 
     // Download via tarball (faster, no git/git-lfs dependency)
     emit_log(window, "Downloading skills...");
@@ -650,17 +647,12 @@ async fn install_skills_to(
         success: true,
         skills_installed: count,
         target_dir: target_str.clone(),
-        message: format!(
-            "Successfully installed {} skills to {}",
-            count, target_str
-        ),
+        message: format!("Successfully installed {} skills to {}", count, target_str),
     })
 }
 
 #[tauri::command]
-pub async fn check_skills_installed(
-    project_path: Option<String>,
-) -> Result<SkillsStatus, String> {
+pub async fn check_skills_installed(project_path: Option<String>) -> Result<SkillsStatus, String> {
     let target = skills_dir(project_path.as_deref());
 
     if !target.exists() {
@@ -686,9 +678,7 @@ pub async fn check_skills_installed(
 }
 
 #[tauri::command]
-pub async fn list_installed_skills(
-    project_path: Option<String>,
-) -> Result<Vec<SkillInfo>, String> {
+pub async fn list_installed_skills(project_path: Option<String>) -> Result<Vec<SkillInfo>, String> {
     let target = skills_dir(project_path.as_deref());
 
     if !target.exists() {
@@ -696,8 +686,8 @@ pub async fn list_installed_skills(
     }
 
     let mut skills = Vec::new();
-    let entries = std::fs::read_dir(&target)
-        .map_err(|e| format!("Failed to read skills dir: {}", e))?;
+    let entries =
+        std::fs::read_dir(&target).map_err(|e| format!("Failed to read skills dir: {}", e))?;
 
     for entry in entries.flatten() {
         if entry.path().is_dir() {
@@ -712,14 +702,11 @@ pub async fn list_installed_skills(
 }
 
 #[tauri::command]
-pub async fn uninstall_scientific_skills(
-    project_path: Option<String>,
-) -> Result<(), String> {
+pub async fn uninstall_scientific_skills(project_path: Option<String>) -> Result<(), String> {
     let target = skills_dir(project_path.as_deref());
 
     if target.exists() {
-        std::fs::remove_dir_all(&target)
-            .map_err(|e| format!("Failed to remove skills: {}", e))?;
+        std::fs::remove_dir_all(&target).map_err(|e| format!("Failed to remove skills: {}", e))?;
     }
 
     Ok(())
@@ -762,7 +749,11 @@ pub async fn get_skill_content(
         .map_err(|e| format!("Failed to fetch from GitHub: {}", e))?;
 
     if !response.status().is_success() {
-        return Err(format!("Skill '{}' not found (HTTP {})", skill_folder, response.status()));
+        return Err(format!(
+            "Skill '{}' not found (HTTP {})",
+            skill_folder,
+            response.status()
+        ));
     }
 
     response
@@ -787,10 +778,7 @@ mod tests {
     #[test]
     fn test_skills_dir_project() {
         let dir = skills_dir(Some("/tmp/my-project"));
-        assert_eq!(
-            dir,
-            PathBuf::from("/tmp/my-project/.claude/skills")
-        );
+        assert_eq!(dir, PathBuf::from("/tmp/my-project/.claude/skills"));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/slash_commands.rs
+++ b/apps/desktop/src-tauri/src/slash_commands.rs
@@ -37,14 +37,22 @@ impl CommandFrontmatterRaw {
         let allowed_tools = self.allowed_tools.and_then(|v| match v {
             serde_yaml::Value::String(s) => {
                 let tools: Vec<String> = s.split_whitespace().map(|t| t.to_string()).collect();
-                if tools.is_empty() { None } else { Some(tools) }
+                if tools.is_empty() {
+                    None
+                } else {
+                    Some(tools)
+                }
             }
             serde_yaml::Value::Sequence(seq) => {
                 let tools: Vec<String> = seq
                     .into_iter()
                     .filter_map(|v| v.as_str().map(|s| s.to_string()))
                     .collect();
-                if tools.is_empty() { None } else { Some(tools) }
+                if tools.is_empty() {
+                    None
+                } else {
+                    Some(tools)
+                }
             }
             _ => None,
         });
@@ -73,7 +81,10 @@ fn parse_markdown_with_frontmatter(content: &str) -> (Option<CommandFrontmatter>
 
     if let Some(end) = frontmatter_end {
         let frontmatter_content = lines.get(1..end).map(|s| s.join("\n")).unwrap_or_default();
-        let body_content = lines.get((end + 1)..).map(|s| s.join("\n")).unwrap_or_default();
+        let body_content = lines
+            .get((end + 1)..)
+            .map(|s| s.join("\n"))
+            .unwrap_or_default();
 
         match serde_yaml::from_str::<CommandFrontmatterRaw>(&frontmatter_content) {
             Ok(raw) => (Some(raw.into_parsed()), body_content),
@@ -101,18 +112,15 @@ fn extract_command_info(file_path: &Path, base_path: &Path) -> Option<(String, O
         Some((components.first()?.to_string(), None))
     } else {
         let command_name = components.last()?.to_string();
-        let namespace = components.get(..components.len() - 1)
+        let namespace = components
+            .get(..components.len() - 1)
             .map(|s| s.join(":"))
             .unwrap_or_default();
         Some((command_name, Some(namespace)))
     }
 }
 
-fn load_command_from_file(
-    file_path: &Path,
-    base_path: &Path,
-    scope: &str,
-) -> Option<SlashCommand> {
+fn load_command_from_file(file_path: &Path, base_path: &Path, scope: &str) -> Option<SlashCommand> {
     let content = fs::read_to_string(file_path).ok()?;
     let (frontmatter, body) = parse_markdown_with_frontmatter(&content);
     let (name, namespace) = extract_command_info(file_path, base_path)?;
@@ -339,9 +347,7 @@ pub async fn slash_commands_list(
             let mut md_files = Vec::new();
             find_markdown_files(&user_commands_dir, &mut md_files);
             for file_path in md_files {
-                if let Some(cmd) =
-                    load_command_from_file(&file_path, &user_commands_dir, "user")
-                {
+                if let Some(cmd) = load_command_from_file(&file_path, &user_commands_dir, "user") {
                     commands.push(cmd);
                 }
             }
@@ -574,7 +580,10 @@ mod tests {
             "Frontmatter with unknown fields (license, metadata) should parse successfully"
         );
         let fm = fm.unwrap();
-        assert_eq!(fm.description.unwrap(), "Comprehensive molecular biology toolkit.");
+        assert_eq!(
+            fm.description.unwrap(),
+            "Comprehensive molecular biology toolkit."
+        );
         assert_eq!(fm.name.unwrap(), "biopython");
         assert!(body.contains("# Biopython"));
     }
@@ -644,17 +653,33 @@ mod tests {
 
         let skills = load_skills_from_dir(dir.path(), "skill");
 
-        assert_eq!(skills.len(), 2, "Should find 2 skills, skip dir without SKILL.md");
+        assert_eq!(
+            skills.len(),
+            2,
+            "Should find 2 skills, skip dir without SKILL.md"
+        );
 
-        let bio = skills.iter().find(|s| s.full_command == "/biopython").unwrap();
+        let bio = skills
+            .iter()
+            .find(|s| s.full_command == "/biopython")
+            .unwrap();
         assert_eq!(bio.name, "biopython");
-        assert_eq!(bio.description.as_deref(), Some("Molecular biology toolkit."));
+        assert_eq!(
+            bio.description.as_deref(),
+            Some("Molecular biology toolkit.")
+        );
         assert_eq!(bio.scope, "skill");
         assert!(bio.accepts_arguments);
 
-        let custom = skills.iter().find(|s| s.full_command == "/custom-tool").unwrap();
+        let custom = skills
+            .iter()
+            .find(|s| s.full_command == "/custom-tool")
+            .unwrap();
         assert_eq!(custom.name, "Custom Tool");
-        assert!(custom.description.is_none(), "No frontmatter = no description");
+        assert!(
+            custom.description.is_none(),
+            "No frontmatter = no description"
+        );
     }
 
     #[test]
@@ -719,7 +744,11 @@ mod tests {
     fn test_load_command_from_file_simple() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("greet.md");
-        fs::write(&file, "Hello $ARGUMENTS, run !`echo hi` and check @main.tex").unwrap();
+        fs::write(
+            &file,
+            "Hello $ARGUMENTS, run !`echo hi` and check @main.tex",
+        )
+        .unwrap();
 
         let cmd = load_command_from_file(&file, dir.path(), "project").unwrap();
         assert_eq!(cmd.name, "greet");
@@ -775,7 +804,10 @@ mod tests {
         find_markdown_files(dir.path(), &mut files);
 
         assert_eq!(files.len(), 2);
-        let names: Vec<String> = files.iter().map(|f| f.file_name().unwrap().to_string_lossy().to_string()).collect();
+        let names: Vec<String> = files
+            .iter()
+            .map(|f| f.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
         assert!(names.contains(&"cmd1.md".to_string()));
         assert!(names.contains(&"cmd2.md".to_string()));
     }
@@ -792,7 +824,10 @@ mod tests {
         find_markdown_files(dir.path(), &mut files);
 
         assert_eq!(files.len(), 1);
-        assert_eq!(files[0].file_name().unwrap().to_str().unwrap(), "visible.md");
+        assert_eq!(
+            files[0].file_name().unwrap().to_str().unwrap(),
+            "visible.md"
+        );
     }
 
     #[test]
@@ -807,7 +842,10 @@ mod tests {
         find_markdown_files(dir.path(), &mut files);
 
         assert_eq!(files.len(), 2);
-        let names: Vec<String> = files.iter().map(|f| f.file_name().unwrap().to_string_lossy().to_string()).collect();
+        let names: Vec<String> = files
+            .iter()
+            .map(|f| f.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
         assert!(names.contains(&"top.md".to_string()));
         assert!(names.contains(&"nested.md".to_string()));
     }
@@ -822,7 +860,10 @@ mod tests {
 
         remove_empty_dirs(&deep);
 
-        assert!(!dir.path().join("a").exists(), "entire empty chain should be removed");
+        assert!(
+            !dir.path().join("a").exists(),
+            "entire empty chain should be removed"
+        );
     }
 
     #[test]
@@ -888,7 +929,11 @@ mod tests {
         assert_eq!(cmd.content, "Do something");
 
         // Verify file was created
-        let file = dir.path().join(".claude").join("commands").join("test-cmd.md");
+        let file = dir
+            .path()
+            .join(".claude")
+            .join("commands")
+            .join("test-cmd.md");
         assert!(file.exists());
         assert_eq!(fs::read_to_string(&file).unwrap(), "Do something");
     }
@@ -943,7 +988,13 @@ mod tests {
         assert_eq!(cmd.full_command, "/tools:rust:clippy");
 
         // Verify nested directory structure
-        let file = dir.path().join(".claude").join("commands").join("tools").join("rust").join("clippy.md");
+        let file = dir
+            .path()
+            .join(".claude")
+            .join("commands")
+            .join("tools")
+            .join("rust")
+            .join("clippy.md");
         assert!(file.exists());
     }
 

--- a/apps/desktop/src-tauri/src/uv.rs
+++ b/apps/desktop/src-tauri/src/uv.rs
@@ -30,11 +30,12 @@ fn find_uv_binary() -> Result<String, String> {
             home.join(".local").join("bin").join("uv.exe"),
             home.join(".cargo").join("bin").join("uv.exe"),
             // %LOCALAPPDATA%\uv\bin\uv.exe
-            PathBuf::from(
-                std::env::var("LOCALAPPDATA").unwrap_or_else(|_| {
-                    home.join("AppData").join("Local").to_string_lossy().to_string()
-                }),
-            )
+            PathBuf::from(std::env::var("LOCALAPPDATA").unwrap_or_else(|_| {
+                home.join("AppData")
+                    .join("Local")
+                    .to_string_lossy()
+                    .to_string()
+            }))
             .join("uv")
             .join("bin")
             .join("uv.exe"),
@@ -50,11 +51,7 @@ fn find_uv_binary() -> Result<String, String> {
     // 3. Check standard paths (Unix only)
     #[cfg(not(target_os = "windows"))]
     {
-        let standard_paths = [
-            "/usr/local/bin/uv",
-            "/opt/homebrew/bin/uv",
-            "/usr/bin/uv",
-        ];
+        let standard_paths = ["/usr/local/bin/uv", "/opt/homebrew/bin/uv", "/usr/bin/uv"];
         for path in &standard_paths {
             if PathBuf::from(path).exists() {
                 return Ok(path.to_string());
@@ -180,12 +177,17 @@ pub async fn install_uv(window: WebviewWindow) -> Result<(), String> {
             let local_dir = home.join(".local");
             let script = format!(
                 "mkdir -p '{}' && chown -R {} '{}'",
-                local_bin.display(), user, local_dir.display()
+                local_bin.display(),
+                user,
+                local_dir.display()
             );
             let output = std::process::Command::new("osascript")
                 .args([
                     "-e",
-                    &format!("do shell script \"{}\" with administrator privileges", script),
+                    &format!(
+                        "do shell script \"{}\" with administrator privileges",
+                        script
+                    ),
                 ])
                 .output()
                 .map_err(|e| format!("Failed to fix permissions for ~/.local: {}", e))?;
@@ -214,7 +216,8 @@ pub async fn install_uv(window: WebviewWindow) -> Result<(), String> {
         c.creation_flags(CREATE_NO_WINDOW);
         c.args([
             "-NoProfile",
-            "-ExecutionPolicy", "Bypass",
+            "-ExecutionPolicy",
+            "Bypass",
             "-Command",
             "irm https://astral.sh/uv/install.ps1 | iex",
         ]);

--- a/apps/desktop/src-tauri/src/zotero.rs
+++ b/apps/desktop/src-tauri/src/zotero.rs
@@ -18,8 +18,11 @@ fn consumer_key() -> String {
 }
 
 fn consumer_secret() -> String {
-    std::env::var("ZOTERO_CONSUMER_SECRET")
-        .unwrap_or_else(|_| option_env!("ZOTERO_CONSUMER_SECRET").unwrap_or("").to_string())
+    std::env::var("ZOTERO_CONSUMER_SECRET").unwrap_or_else(|_| {
+        option_env!("ZOTERO_CONSUMER_SECRET")
+            .unwrap_or("")
+            .to_string()
+    })
 }
 
 const REQUEST_TOKEN_URL: &str = "https://www.zotero.org/oauth/request";
@@ -81,8 +84,8 @@ fn get_timestamp() -> String {
 }
 
 fn hmac_sha1(key: &str, message: &str) -> Result<String, String> {
-    let mut mac = HmacSha1::new_from_slice(key.as_bytes())
-        .map_err(|e| format!("Invalid HMAC key: {}", e))?;
+    let mut mac =
+        HmacSha1::new_from_slice(key.as_bytes()).map_err(|e| format!("Invalid HMAC key: {}", e))?;
     mac.update(message.as_bytes());
     Ok(BASE64.encode(mac.finalize().into_bytes()))
 }
@@ -322,7 +325,8 @@ pub async fn zotero_start_oauth(
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .map_err(|e| format!("Failed to bind local server: {}", e))?;
-    let port = listener.local_addr()
+    let port = listener
+        .local_addr()
         .map_err(|e| format!("Failed to get local address: {}", e))?
         .port();
     let callback_url = format!("http://127.0.0.1:{}/callback", port);
@@ -363,9 +367,7 @@ pub async fn zotero_complete_oauth(
 }
 
 #[tauri::command]
-pub async fn zotero_cancel_oauth(
-    state: tauri::State<'_, ZoteroOAuthState>,
-) -> Result<(), String> {
+pub async fn zotero_cancel_oauth(state: tauri::State<'_, ZoteroOAuthState>) -> Result<(), String> {
     *state.lock().await = None;
     Ok(())
 }
@@ -404,7 +406,9 @@ mod tests {
         // HMAC-SHA1("key", "The quick brown fox jumps over the lazy dog") is a known value
         assert!(!result.is_empty());
         // Base64 encoded, should contain only valid base64 chars
-        assert!(result.chars().all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '/' || c == '='));
+        assert!(result
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '/' || c == '='));
     }
 
     #[test]
@@ -412,14 +416,25 @@ mod tests {
         let params = vec![
             ("oauth_consumer_key".to_string(), "key123".to_string()),
             ("oauth_nonce".to_string(), "nonce".to_string()),
-            ("oauth_signature_method".to_string(), "HMAC-SHA1".to_string()),
+            (
+                "oauth_signature_method".to_string(),
+                "HMAC-SHA1".to_string(),
+            ),
             ("oauth_timestamp".to_string(), "1234567890".to_string()),
             ("oauth_version".to_string(), "1.0".to_string()),
         ];
-        let sig = oauth_signature("POST", "https://example.com/api", &params, "consumer_secret", "token_secret");
+        let sig = oauth_signature(
+            "POST",
+            "https://example.com/api",
+            &params,
+            "consumer_secret",
+            "token_secret",
+        );
         assert!(!sig.is_empty());
         // Should be valid base64
-        assert!(sig.chars().all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '/' || c == '='));
+        assert!(sig
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '/' || c == '='));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/nicegui-unofficial/nicegui-tauri-template/main/src-tauri/tauri.conf-v2-schema.json",
   "identifier": "com.claude-prism.desktop",
   "productName": "ClaudePrism",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",
@@ -26,7 +26,8 @@
         "trafficLightPosition": {
           "x": 12,
           "y": 12
-        }
+        },
+        "backgroundThrottling": "disabled"
       }
     ],
     "security": {
@@ -36,6 +37,7 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -55,5 +57,12 @@
       }
     }
   },
-  "plugins": {}
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDFBMjhBQjdENzM3QjY2QTYKUldTbVpudHpmYXNvR2pVK3M1Rmc2cjRORit3dVBaYkZhWnUxWThha1IxVW9rZ0ZFSnhLZ2tSOHMK",
+      "endpoints": [
+        "https://github.com/delibae/claude-prism/releases/latest/download/latest.json"
+      ]
+    }
+  }
 }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2,6 +2,7 @@ import { ThemeProvider } from "next-themes";
 import { ErrorBoundary } from "react-error-boundary";
 import { Toaster } from "@/components/ui/sonner";
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
+import { useUpdater } from "@/hooks/use-updater";
 import { useDocumentStore } from "@/stores/document-store";
 import { useClaudeChatStore } from "@/stores/claude-chat-store";
 import { ProjectPicker } from "@/components/project-picker";
@@ -87,6 +88,9 @@ export function App({ onReady }: { onReady?: () => void }) {
 
   // Register global keyboard shortcuts (Cmd+S, Cmd+N) at the app level
   useKeyboardShortcuts();
+
+  // Check for app updates
+  useUpdater();
 
   useEffect(() => {
     onReady?.();

--- a/apps/desktop/src/hooks/use-updater.ts
+++ b/apps/desktop/src/hooks/use-updater.ts
@@ -1,0 +1,80 @@
+import { useEffect, useRef } from "react";
+import { check } from "@tauri-apps/plugin-updater";
+import { relaunch } from "@tauri-apps/plugin-process";
+import { toast } from "sonner";
+
+const CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+const INITIAL_DELAY_MS = 5_000; // 5 seconds after mount
+
+export function useUpdater() {
+  const checking = useRef(false);
+
+  useEffect(() => {
+    async function checkForUpdate() {
+      if (checking.current) return;
+      checking.current = true;
+
+      try {
+        const update = await check();
+        if (!update) return;
+
+        toast(`Update available: v${update.version}`, {
+          description: update.body || "A new version is ready to install.",
+          duration: Infinity,
+          action: {
+            label: "Update",
+            onClick: () => installUpdate(update),
+          },
+        });
+      } catch (err) {
+        console.error("Update check failed:", err);
+      } finally {
+        checking.current = false;
+      }
+    }
+
+    const initialTimer = setTimeout(checkForUpdate, INITIAL_DELAY_MS);
+    const interval = setInterval(checkForUpdate, CHECK_INTERVAL_MS);
+
+    return () => {
+      clearTimeout(initialTimer);
+      clearInterval(interval);
+    };
+  }, []);
+}
+
+async function installUpdate(update: Awaited<ReturnType<typeof check>>) {
+  if (!update) return;
+
+  const toastId = toast.loading("Downloading update...", {
+    duration: Infinity,
+  });
+
+  try {
+    let downloaded = 0;
+    let contentLength = 0;
+
+    await update.downloadAndInstall((event) => {
+      switch (event.event) {
+        case "Started":
+          contentLength = event.data.contentLength ?? 0;
+          break;
+        case "Progress":
+          downloaded += event.data.chunkLength;
+          if (contentLength > 0) {
+            const pct = Math.round((downloaded / contentLength) * 100);
+            toast.loading(`Downloading update... ${pct}%`, { id: toastId });
+          }
+          break;
+        case "Finished":
+          toast.loading("Installing...", { id: toastId });
+          break;
+      }
+    });
+
+    toast.success("Update complete. Restarting...", { id: toastId, duration: 2000 });
+    setTimeout(() => relaunch(), 2000);
+  } catch (err) {
+    toast.error(`Update failed: ${err}`, { id: toastId, duration: 5000 });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@claude-prism/root",
   "description": "Open-Source AI LaTeX writing workspace",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/delibae/claude-prism"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@tauri-apps/plugin-shell':
         specifier: ^2.2.2
         version: 2.3.5
+      '@tauri-apps/plugin-updater':
+        specifier: ~2.10.0
+        version: 2.10.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3094,6 +3097,9 @@ packages:
 
   '@tauri-apps/plugin-shell@2.3.5':
     resolution: {integrity: sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==}
+
+  '@tauri-apps/plugin-updater@2.10.0':
+    resolution: {integrity: sha512-ljN8jPlnT0aSn8ecYhuBib84alxfMx6Hc8vJSKMJyzGbTPFZAC44T2I1QNFZssgWKrAlofvJqCC6Rr472JWfkQ==}
 
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
@@ -9777,6 +9783,10 @@ snapshots:
       '@tauri-apps/api': 2.10.1
 
   '@tauri-apps/plugin-shell@2.3.5':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-updater@2.10.0':
     dependencies:
       '@tauri-apps/api': 2.10.1
 

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Load env vars (for TAURI_SIGNING_PRIVATE_KEY_PATH)
+ENV_FILE="apps/desktop/src-tauri/.env"
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  source "$ENV_FILE"
+  set +a
+fi
+
+# Require signing key for updater
+if [ -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
+  echo "Error: TAURI_SIGNING_PRIVATE_KEY is not set"
+  echo "  Local: set it in apps/desktop/src-tauri/.env"
+  echo "  CI:    set it as a GitHub Actions secret"
+  exit 1
+fi
+
 TARGET="x86_64-unknown-linux-gnu"
 VERSION=$(node -p "require('./package.json').version")
 TAG="v${VERSION}"
@@ -20,6 +36,7 @@ BUNDLE_DIR="apps/desktop/src-tauri/target/$TARGET/release/bundle"
 DEB_PATH=$(find "$BUNDLE_DIR/deb" -name '*.deb' 2>/dev/null | head -1)
 RPM_PATH=$(find "$BUNDLE_DIR/rpm" -name '*.rpm' 2>/dev/null | head -1)
 APPIMAGE_PATH=$(find "$BUNDLE_DIR/appimage" -name '*.AppImage' 2>/dev/null | head -1)
+APPIMAGE_SIG=$(find "$BUNDLE_DIR/appimage" -name '*.AppImage.sig' 2>/dev/null | head -1)
 
 ASSETS=()
 [ -n "$DEB_PATH" ] && ASSETS+=("$DEB_PATH")
@@ -33,6 +50,46 @@ fi
 
 echo "==> Build artifacts:"
 printf "    %s\n" "${ASSETS[@]}"
+
+# --- Auto-updater artifacts ---
+if [ -n "$APPIMAGE_PATH" ] && [ -n "$APPIMAGE_SIG" ]; then
+  SIGNATURE=$(cat "$APPIMAGE_SIG")
+  PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  APPIMAGE_FILENAME=$(basename "$APPIMAGE_PATH")
+
+  # Generate latest.json (merge with existing if present)
+  LATEST_JSON="apps/desktop/src-tauri/target/latest.json"
+
+  if [ -f "$LATEST_JSON" ]; then
+    node -e "
+      const fs = require('fs');
+      const data = JSON.parse(fs.readFileSync('$LATEST_JSON', 'utf8'));
+      data.platforms['linux-x86_64'] = {
+        signature: \`$SIGNATURE\`,
+        url: 'https://github.com/delibae/claude-prism/releases/download/$TAG/$APPIMAGE_FILENAME'
+      };
+      fs.writeFileSync('$LATEST_JSON', JSON.stringify(data, null, 2));
+    "
+  else
+    cat > "$LATEST_JSON" <<EOF
+{
+  "version": "$VERSION",
+  "notes": "ClaudePrism $TAG",
+  "pub_date": "$PUB_DATE",
+  "platforms": {
+    "linux-x86_64": {
+      "signature": "$SIGNATURE",
+      "url": "https://github.com/delibae/claude-prism/releases/download/$TAG/$APPIMAGE_FILENAME"
+    }
+  }
+}
+EOF
+  fi
+  echo "==> Generated latest.json with linux-x86_64"
+  ASSETS+=("$LATEST_JSON")
+else
+  echo "Warning: AppImage updater artifacts not found, skipping latest.json"
+fi
 
 # Upload to GitHub Release
 echo "==> Uploading to GitHub Release $TAG"

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -12,6 +12,14 @@ else
   exit 1
 fi
 
+# Require signing key for updater
+if [ -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
+  echo "Error: TAURI_SIGNING_PRIVATE_KEY is not set"
+  echo "  Local: set it in apps/desktop/src-tauri/.env"
+  echo "  CI:    set it as a GitHub Actions secret"
+  exit 1
+fi
+
 TARGET="aarch64-apple-darwin"
 VERSION=$(node -p "require('./package.json').version")
 TAG="v${VERSION}"
@@ -46,14 +54,62 @@ echo "==> Stapling..."
 xcrun stapler staple "$DMG_PATH"
 xcrun stapler staple "$APP_PATH"
 
+# --- Auto-updater artifacts ---
+BUNDLE_DIR="apps/desktop/src-tauri/target/$TARGET/release/bundle"
+UPDATE_TAR=$(find "$BUNDLE_DIR/macos" -name '*.app.tar.gz' | head -1)
+UPDATE_SIG=$(find "$BUNDLE_DIR/macos" -name '*.app.tar.gz.sig' | head -1)
+
+if [ -z "$UPDATE_TAR" ] || [ -z "$UPDATE_SIG" ]; then
+  echo "Warning: Updater artifacts not found, skipping latest.json"
+else
+  SIGNATURE=$(cat "$UPDATE_SIG")
+  PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  UPDATE_FILENAME=$(basename "$UPDATE_TAR")
+
+  # Generate latest.json (merge with existing if present)
+  LATEST_JSON="apps/desktop/src-tauri/target/latest.json"
+
+  if [ -f "$LATEST_JSON" ]; then
+    # Merge: add this platform to existing latest.json
+    node -e "
+      const fs = require('fs');
+      const data = JSON.parse(fs.readFileSync('$LATEST_JSON', 'utf8'));
+      data.platforms['darwin-aarch64'] = {
+        signature: \`$SIGNATURE\`,
+        url: 'https://github.com/delibae/claude-prism/releases/download/$TAG/$UPDATE_FILENAME'
+      };
+      fs.writeFileSync('$LATEST_JSON', JSON.stringify(data, null, 2));
+    "
+  else
+    cat > "$LATEST_JSON" <<EOF
+{
+  "version": "$VERSION",
+  "notes": "ClaudePrism $TAG",
+  "pub_date": "$PUB_DATE",
+  "platforms": {
+    "darwin-aarch64": {
+      "signature": "$SIGNATURE",
+      "url": "https://github.com/delibae/claude-prism/releases/download/$TAG/$UPDATE_FILENAME"
+    }
+  }
+}
+EOF
+  fi
+  echo "==> Generated latest.json with darwin-aarch64"
+fi
+
 # Upload to GitHub Release
 echo "==> Uploading to GitHub Release $TAG"
 gh release view "$TAG" --repo delibae/claude-prism >/dev/null 2>&1 || \
   gh release create "$TAG" --repo delibae/claude-prism --title "ClaudePrism $TAG" --generate-notes
 
+UPLOAD_ASSETS=("$DMG_PATH")
+[ -n "${UPDATE_TAR:-}" ] && UPLOAD_ASSETS+=("$UPDATE_TAR")
+[ -f "${LATEST_JSON:-}" ] && UPLOAD_ASSETS+=("$LATEST_JSON")
+
 gh release upload "$TAG" \
   --repo delibae/claude-prism \
   --clobber \
-  "$DMG_PATH"
+  "${UPLOAD_ASSETS[@]}"
 
 echo "==> Done! macOS build uploaded to $TAG"


### PR DESCRIPTION
## Summary
- Add Tauri auto-updater plugin with signed update artifacts and GitHub Releases endpoint
- Fix macOS black screen on app switch by setting `backgroundThrottling: "disabled"` (WKWebView suspension issue on Apple Silicon)
- Add update check UI with toast notifications using sonner
- Update build scripts (macOS/Linux) to generate `latest.json` with signatures
- Add multi-platform CI workflow with draft release → publish pattern
- Bump version to 1.0.1

## Test plan
- [ ] macOS: switch to another app and back — no black screen
- [ ] Build produces `.sig` files and `latest.json`
- [ ] CI workflow creates draft release, uploads all artifacts, then publishes
- [ ] Update toast appears when a newer version is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)