### PR TITLE
fix: set PKG_CONFIG_PATH for macOS CI brew deps

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -132,7 +132,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install macOS dependencies
-        run: brew install icu4c harfbuzz pkg-config
+        run: |
+          brew install icu4c harfbuzz pkg-config graphite2 freetype
+          echo "PKG_CONFIG_PATH=$(brew --prefix icu4c)/lib/pkgconfig:$(brew --prefix harfbuzz)/lib/pkgconfig:$(brew --prefix graphite2)/lib/pkgconfig:$(brew --prefix freetype)/lib/pkgconfig:$(brew --prefix libpng)/lib/pkgconfig" >> $GITHUB_ENV
 
       - name: Import Apple certificate
         env:


### PR DESCRIPTION
## Summary
- Install graphite2 and freetype explicitly
- Set PKG_CONFIG_PATH so tectonic can find harfbuzz/icu4c/graphite2/freetype headers from brew

Fixes `fatal error: 'harfbuzz/hb.h' file not found` in CI macOS build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)