### PR TITLE
fix: add CPPFLAGS/LDFLAGS for macOS CI harfbuzz

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -133,8 +133,12 @@ jobs:
 
       - name: Install macOS dependencies
         run: |
-          brew install icu4c harfbuzz pkg-config graphite2 freetype
-          echo "PKG_CONFIG_PATH=$(brew --prefix icu4c)/lib/pkgconfig:$(brew --prefix harfbuzz)/lib/pkgconfig:$(brew --prefix graphite2)/lib/pkgconfig:$(brew --prefix freetype)/lib/pkgconfig:$(brew --prefix libpng)/lib/pkgconfig" >> $GITHUB_ENV
+          brew install icu4c harfbuzz pkg-config graphite2 freetype fontconfig
+          {
+            echo "PKG_CONFIG_PATH=$(brew --prefix icu4c)/lib/pkgconfig:$(brew --prefix harfbuzz)/lib/pkgconfig:$(brew --prefix graphite2)/lib/pkgconfig:$(brew --prefix freetype)/lib/pkgconfig:$(brew --prefix libpng)/lib/pkgconfig:$(brew --prefix fontconfig)/lib/pkgconfig"
+            echo "CPPFLAGS=-I$(brew --prefix harfbuzz)/include -I$(brew --prefix freetype)/include -I$(brew --prefix graphite2)/include -I$(brew --prefix icu4c)/include"
+            echo "LDFLAGS=-L$(brew --prefix harfbuzz)/lib -L$(brew --prefix freetype)/lib -L$(brew --prefix graphite2)/lib -L$(brew --prefix icu4c)/lib"
+          } >> $GITHUB_ENV
 
       - name: Import Apple certificate
         env:


### PR DESCRIPTION
## Summary
- Add CPPFLAGS with brew include paths so `#include <harfbuzz/hb.h>` resolves correctly
- Add LDFLAGS for linker paths
- Install fontconfig explicitly

pkg-config was finding harfbuzz but passing `-I .../include/harfbuzz` instead of `-I .../include`, causing the nested `harfbuzz/hb.h` lookup to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)