### PR TITLE
fix: remove TAURI_SIGNING_PRIVATE_KEY_PASSWORD env

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -16,7 +16,6 @@ permissions:
 
 env:
   TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-  TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
 
 jobs:
   # ──────────────────────────────────────────────


### PR DESCRIPTION
Empty string "" is treated as a password by Tauri. Key was generated without password, so omit the env var entirely.