### PR TITLE
fix: regenerate signing key with explicit password

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -16,6 +16,7 @@ permissions:
 
 env:
   TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+  TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
 jobs:
   # ──────────────────────────────────────────────

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -59,7 +59,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDFBMjhBQjdENzM3QjY2QTYKUldTbVpudHpmYXNvR2pVK3M1Rmc2cjRORit3dVBaYkZhWnUxWThha1IxVW9rZ0ZFSnhLZ2tSOHMK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IENBNjAzOTI2NzdDQjdBNkMKUldSc2VzdDNKamxneXMzUnZIK0h3TzZ4WVo4QVFVQlRaSFA1TEhCcGtUYW53ZkhNaDluaWgwZWQK",
       "endpoints": [
         "https://github.com/delibae/claude-prism/releases/latest/download/latest.json"
       ]


### PR DESCRIPTION
Key generated with --ci had no usable password. Regenerated with explicit password, updated pubkey and workflow.