### PR TITLE
fix: version-free direct download links in READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -24,13 +24,13 @@
   <a href="https://claudeprism.delibae.dev?utm_source=github&utm_medium=readme&utm_campaign=launch_v054">
     <img src="https://img.shields.io/badge/Website-claudeprism.dev-blue?style=flat-square&logo=googlechrome&logoColor=white" alt="Website" />
   </a>&nbsp;
-  <a href="https://github.com/delibae/claude-prism/releases/latest">
+  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism-macOS.dmg">
     <img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-black?style=for-the-badge&logo=apple&logoColor=white" alt="macOS 版をダウンロード" />
   </a>&nbsp;
-  <a href="https://github.com/delibae/claude-prism/releases/latest">
+  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism-Windows-setup.exe">
     <img src="https://img.shields.io/badge/Download-Windows-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Windows 版をダウンロード" />
   </a>&nbsp;
-  <a href="https://github.com/delibae/claude-prism/releases/latest">
+  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism-Linux.deb">
     <img src="https://img.shields.io/badge/Download-Linux_(deb)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux 版をダウンロード" />
   </a>
 </p>

--- a/README.ko.md
+++ b/README.ko.md
@@ -24,13 +24,13 @@
   <a href="https://claudeprism.delibae.dev?utm_source=github&utm_medium=readme&utm_campaign=launch_v054">
     <img src="https://img.shields.io/badge/Website-claudeprism.dev-blue?style=flat-square&logo=googlechrome&logoColor=white" alt="Website" />
   </a>&nbsp;
-  <a href="https://github.com/delibae/claude-prism/releases/latest">
+  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism-macOS.dmg">
     <img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-black?style=for-the-badge&logo=apple&logoColor=white" alt="macOS 다운로드" />
   </a>&nbsp;
-  <a href="https://github.com/delibae/claude-prism/releases/latest">
+  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism-Windows-setup.exe">
     <img src="https://img.shields.io/badge/Download-Windows-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Windows 다운로드" />
   </a>&nbsp;
-  <a href="https://github.com/delibae/claude-prism/releases/latest">
+  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism-Linux.deb">
     <img src="https://img.shields.io/badge/Download-Linux_(deb)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux 다운로드" />
   </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@
   <a href="https://claudeprism.delibae.dev?utm_source=github&utm_medium=readme&utm_campaign=launch_v054">
     <img src="https://img.shields.io/badge/Website-claudeprism.dev-blue?style=flat-square&logo=googlechrome&logoColor=white" alt="Website" />
   </a>&nbsp;
-  <a href="https://github.com/delibae/claude-prism/releases/latest">
+  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism-macOS.dmg">
     <img src="https://img.shields.io/badge/Download-macOS_(Apple_Silicon)-black?style=for-the-badge&logo=apple&logoColor=white" alt="Download for macOS" />
   </a>&nbsp;
-  <a href="https://github.com/delibae/claude-prism/releases/latest">
+  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism-Windows-setup.exe">
     <img src="https://img.shields.io/badge/Download-Windows-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Download for Windows" />
   </a>&nbsp;
-  <a href="https://github.com/delibae/claude-prism/releases/latest">
+  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism-Linux.deb">
     <img src="https://img.shields.io/badge/Download-Linux_(deb)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Download for Linux" />
   </a>
 </p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,9 +22,9 @@
 
 <p align="center">
   <a href="https://claudeprism.delibae.dev?utm_source=github&utm_medium=readme&utm_campaign=launch_v054">官网</a> ·
-  <a href="https://github.com/delibae/claude-prism/releases/latest">macOS</a> ·
-  <a href="https://github.com/delibae/claude-prism/releases/latest">Windows</a> ·
-  <a href="https://github.com/delibae/claude-prism/releases/latest">Linux</a> ·
+  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism-macOS.dmg">macOS</a> ·
+  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism-Windows-setup.exe">Windows</a> ·
+  <a href="https://github.com/delibae/claude-prism/releases/latest/download/ClaudePrism-Linux.deb">Linux</a> ·
   <a href="https://github.com/delibae/claude-prism/releases">所有版本</a>
 </p>
 


### PR DESCRIPTION
Point download badges to /releases/latest/download/ClaudePrism-{platform} so links never go stale.