### PR TITLE
fix: resolve all platform-specific Rust build warnings

### DIFF
--- a/apps/desktop/src-tauri/src/claude.rs
+++ b/apps/desktop/src-tauri/src/claude.rs
@@ -12,6 +12,9 @@ use tokio::sync::Mutex;
 #[cfg(target_os = "windows")]
 const CREATE_NO_WINDOW: u32 = 0x08000000;
 
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+
 #[derive(Clone)]
 pub struct ClaudeProcessState {
     pub processes: Arc<Mutex<HashMap<String, Child>>>,
@@ -46,6 +49,7 @@ fn find_claude_binary() -> Result<String, String> {
     }
 
     // 3. Check NVM directories (Unix) or npm global (Windows)
+    #[allow(unused_variables)]
     if let Some(home) = dirs::home_dir() {
         #[cfg(not(target_os = "windows"))]
         {
@@ -258,7 +262,7 @@ fn resolve_cmd_to_node(program: &str) -> (String, Vec<String>) {
 fn new_sync_command(program: &str) -> std::process::Command {
     #[cfg(target_os = "windows")]
     {
-        use std::os::windows::process::CommandExt;
+
         let (resolved, prefix) = resolve_cmd_to_node(program);
         let mut c = std::process::Command::new(&resolved);
         c.creation_flags(CREATE_NO_WINDOW);
@@ -284,7 +288,7 @@ fn create_command(
 
     #[cfg(target_os = "windows")]
     let mut cmd = {
-        use std::os::windows::process::CommandExt;
+
         let (resolved, prefix) = resolve_cmd_to_node(clean_program.as_ref());
         let mut c = Command::new(&resolved);
         c.creation_flags(CREATE_NO_WINDOW);
@@ -676,6 +680,7 @@ pub async fn check_claude_status() -> Result<ClaudeStatus, String> {
 }
 
 /// Return the list of directories the Claude Code installer needs.
+#[cfg(not(target_os = "windows"))]
 fn claude_required_dirs(home: &std::path::Path) -> Vec<PathBuf> {
     vec![
         home.join(".local").join("bin"),
@@ -687,11 +692,13 @@ fn claude_required_dirs(home: &std::path::Path) -> Vec<PathBuf> {
 
 /// Try to create all required directories without elevation.
 /// Returns Ok(true) if all succeeded, Ok(false) if any failed.
+#[cfg(not(target_os = "windows"))]
 fn try_create_dirs(dirs: &[PathBuf]) -> bool {
     dirs.iter().all(|dir| std::fs::create_dir_all(dir).is_ok())
 }
 
 /// Verify that all directories exist and are writable.
+#[cfg(not(target_os = "windows"))]
 fn verify_dirs_writable(dirs: &[PathBuf]) -> Result<(), String> {
     for dir in dirs {
         if !dir.exists() {
@@ -798,7 +805,7 @@ pub async fn install_claude_cli(window: WebviewWindow) -> Result<(), String> {
     };
     #[cfg(target_os = "windows")]
     let mut cmd = {
-        use std::os::windows::process::CommandExt;
+
         let mut c = tokio::process::Command::new("powershell");
         c.creation_flags(CREATE_NO_WINDOW);
         c.args([
@@ -908,7 +915,7 @@ pub async fn login_claude(window: WebviewWindow) -> Result<(), String> {
 
     #[cfg(target_os = "windows")]
     let mut cmd = {
-        use std::os::windows::process::CommandExt;
+
         let (resolved, prefix) = resolve_cmd_to_node(&binary_path);
         let mut c = tokio::process::Command::new(&resolved);
         c.creation_flags(CREATE_NO_WINDOW);

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -170,6 +170,7 @@ fn create_new_window(app: tauri::AppHandle) -> Result<(), String> {
             .as_millis()
     );
 
+    #[allow(unused_mut)]
     let mut builder = WebviewWindowBuilder::new(&app, &label, WebviewUrl::default())
         .title("ClaudePrism")
         .inner_size(1400.0, 900.0)

--- a/apps/desktop/src-tauri/src/skills.rs
+++ b/apps/desktop/src-tauri/src/skills.rs
@@ -570,6 +570,7 @@ fn ensure_target_writable(target: &Path) -> Result<(), String> {
             )
         })?;
         let _ = std::fs::remove_file(&test_file);
+        return Ok(());
     }
 
     #[cfg(target_os = "windows")]
@@ -579,8 +580,6 @@ fn ensure_target_writable(target: &Path) -> Result<(), String> {
             target.display()
         ));
     }
-
-    Ok(())
 }
 
 /// Emit a progress log event to the frontend + stderr for terminal debugging.

--- a/apps/desktop/src-tauri/src/uv.rs
+++ b/apps/desktop/src-tauri/src/uv.rs
@@ -7,6 +7,9 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 #[cfg(target_os = "windows")]
 const CREATE_NO_WINDOW: u32 = 0x08000000;
 
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+
 // ─── Binary Discovery ───
 
 /// Discover the uv binary on the system.
@@ -140,7 +143,7 @@ pub async fn check_uv_status() -> Result<UvStatus, String> {
     version_cmd.arg("--version");
     #[cfg(target_os = "windows")]
     {
-        use std::os::windows::process::CommandExt;
+
         version_cmd.creation_flags(CREATE_NO_WINDOW);
     }
     let version_output = version_cmd.output();
@@ -211,7 +214,7 @@ pub async fn install_uv(window: WebviewWindow) -> Result<(), String> {
     };
     #[cfg(target_os = "windows")]
     let mut cmd = {
-        use std::os::windows::process::CommandExt;
+
         let mut c = tokio::process::Command::new("powershell");
         c.creation_flags(CREATE_NO_WINDOW);
         c.args([
@@ -328,7 +331,7 @@ pub async fn setup_project_venv(project_path: String) -> Result<VenvInfo, String
     venv_cmd.current_dir(project);
     #[cfg(target_os = "windows")]
     {
-        use std::os::windows::process::CommandExt;
+
         venv_cmd.creation_flags(CREATE_NO_WINDOW);
     }
     let output = venv_cmd
@@ -372,7 +375,7 @@ pub async fn uv_add_packages(
     pip_cmd.env("PATH", path_with_venv(&venv_dir));
     #[cfg(target_os = "windows")]
     {
-        use std::os::windows::process::CommandExt;
+
         pip_cmd.creation_flags(CREATE_NO_WINDOW);
     }
     let output = pip_cmd
@@ -416,7 +419,7 @@ pub async fn uv_run_command(
     run_cmd.env("PATH", path_with_venv(&venv_dir));
     #[cfg(target_os = "windows")]
     {
-        use std::os::windows::process::CommandExt;
+
         run_cmd.creation_flags(CREATE_NO_WINDOW);
     }
     let output = run_cmd


### PR DESCRIPTION
## Summary
- Move `CommandExt` imports to module level with `#[cfg(windows)]` (eliminates 7 duplicate import warnings)
- Add `#[cfg(not(windows))]` to Unix-only dir helper functions (eliminates 3 dead code warnings)
- Add `#[allow(unused_mut)]` on window builder (mut only needed on macOS)
- Add `#[allow(unused_variables)]` on home variable (used only on Unix)
- Fix unreachable `Ok(())` in skills.rs after `#[cfg]` return branches

All 13 Windows warnings + 1 Linux warning resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)