### PR TITLE
fix: update quickstart URL to include locale path

### DIFF
--- a/apps/desktop/src/components/claude-setup.tsx
+++ b/apps/desktop/src/components/claude-setup.tsx
@@ -366,7 +366,7 @@ export function ClaudeSetup() {
               size="sm"
               className="gap-2 text-muted-foreground"
               onClick={() => {
-                shellOpen("https://code.claude.com/docs/quickstart");
+                shellOpen("https://code.claude.com/docs/en/quickstart");
               }}
             >
               <ExternalLinkIcon className="size-3.5" />


### PR DESCRIPTION
## Summary
- Update quickstart docs URL from `/docs/quickstart` to `/docs/en/quickstart`

## Test plan
- [ ] Verify the Setup Guide link opens the correct page

🤖 Generated with [Claude Code](https://claude.com/claude-code)