### PR TITLE
fix: static link macOS builds via vcpkg (closes #77)

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -130,16 +130,45 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install macOS dependencies
+      # Static linking via vcpkg — avoids runtime dependency on Homebrew dylibs.
+      # Ref: https://tectonic-typesetting.github.io/book/latest/howto/build-tectonic/
+      # Ref: https://learn.microsoft.com/en-us/vcpkg/users/triplets (arm64-osx defaults to static)
+      - name: Setup vcpkg
         run: |
-          brew install icu4c harfbuzz pkg-config graphite2 freetype fontconfig
-          INCLUDES="-I$(brew --prefix harfbuzz)/include -I$(brew --prefix freetype)/include -I$(brew --prefix graphite2)/include -I$(brew --prefix icu4c)/include"
-          {
-            echo "PKG_CONFIG_PATH=$(brew --prefix icu4c)/lib/pkgconfig:$(brew --prefix harfbuzz)/lib/pkgconfig:$(brew --prefix graphite2)/lib/pkgconfig:$(brew --prefix freetype)/lib/pkgconfig:$(brew --prefix libpng)/lib/pkgconfig:$(brew --prefix fontconfig)/lib/pkgconfig"
-            echo "CXXFLAGS=-std=c++17 $INCLUDES"
-            echo "CFLAGS=$INCLUDES"
-            echo "LDFLAGS=-L$(brew --prefix harfbuzz)/lib -L$(brew --prefix freetype)/lib -L$(brew --prefix graphite2)/lib -L$(brew --prefix icu4c)/lib"
-          } >> $GITHUB_ENV
+          git clone --depth 1 https://github.com/microsoft/vcpkg $HOME/vcpkg
+          $HOME/vcpkg/bootstrap-vcpkg.sh
+          echo "VCPKG_ROOT=$HOME/vcpkg" >> $GITHUB_ENV
+
+      - name: Restore vcpkg cache
+        id: vcpkg-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/vcpkg/installed
+          key: vcpkg-macos-arm64-v1
+
+      - name: Install macOS dependencies (vcpkg)
+        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
+        env:
+          VCPKG_BINARY_SOURCES: "clear"
+        run: |
+          $HOME/vcpkg/vcpkg install \
+            "harfbuzz[graphite2]:arm64-osx" \
+            fontconfig:arm64-osx \
+            freetype:arm64-osx \
+            icu:arm64-osx
+
+      - name: Save vcpkg cache
+        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/vcpkg/installed
+          key: vcpkg-macos-arm64-v1
+
+      - name: Set macOS build environment
+        run: |
+          echo "TECTONIC_DEP_BACKEND=vcpkg" >> $GITHUB_ENV
+          echo "CXXFLAGS=-std=c++17" >> $GITHUB_ENV
+          echo "CFLAGS=" >> $GITHUB_ENV
 
       - name: Import Apple certificate
         env:
@@ -186,7 +215,6 @@ jobs:
           ZOTERO_CONSUMER_KEY: ${{ secrets.ZOTERO_CONSUMER_KEY }}
           ZOTERO_CONSUMER_SECRET: ${{ secrets.ZOTERO_CONSUMER_SECRET }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          TECTONIC_DEP_BACKEND: pkg-config
         run: pnpm --filter @claude-prism/desktop tauri build --target aarch64-apple-darwin
 
       - name: Notarize DMG
@@ -257,16 +285,43 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install macOS dependencies
+      # Static linking via vcpkg — same approach as Apple Silicon and Windows.
+      - name: Setup vcpkg
         run: |
-          brew install icu4c harfbuzz pkg-config graphite2 freetype fontconfig
-          INCLUDES="-I$(brew --prefix harfbuzz)/include -I$(brew --prefix freetype)/include -I$(brew --prefix graphite2)/include -I$(brew --prefix icu4c)/include"
-          {
-            echo "PKG_CONFIG_PATH=$(brew --prefix icu4c)/lib/pkgconfig:$(brew --prefix harfbuzz)/lib/pkgconfig:$(brew --prefix graphite2)/lib/pkgconfig:$(brew --prefix freetype)/lib/pkgconfig:$(brew --prefix libpng)/lib/pkgconfig:$(brew --prefix fontconfig)/lib/pkgconfig"
-            echo "CXXFLAGS=-std=c++17 $INCLUDES"
-            echo "CFLAGS=$INCLUDES"
-            echo "LDFLAGS=-L$(brew --prefix harfbuzz)/lib -L$(brew --prefix freetype)/lib -L$(brew --prefix graphite2)/lib -L$(brew --prefix icu4c)/lib"
-          } >> $GITHUB_ENV
+          git clone --depth 1 https://github.com/microsoft/vcpkg $HOME/vcpkg
+          $HOME/vcpkg/bootstrap-vcpkg.sh
+          echo "VCPKG_ROOT=$HOME/vcpkg" >> $GITHUB_ENV
+
+      - name: Restore vcpkg cache
+        id: vcpkg-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/vcpkg/installed
+          key: vcpkg-macos-x64-v1
+
+      - name: Install macOS dependencies (vcpkg)
+        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
+        env:
+          VCPKG_BINARY_SOURCES: "clear"
+        run: |
+          $HOME/vcpkg/vcpkg install \
+            "harfbuzz[graphite2]:x64-osx" \
+            fontconfig:x64-osx \
+            freetype:x64-osx \
+            icu:x64-osx
+
+      - name: Save vcpkg cache
+        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/vcpkg/installed
+          key: vcpkg-macos-x64-v1
+
+      - name: Set macOS build environment
+        run: |
+          echo "TECTONIC_DEP_BACKEND=vcpkg" >> $GITHUB_ENV
+          echo "CXXFLAGS=-std=c++17" >> $GITHUB_ENV
+          echo "CFLAGS=" >> $GITHUB_ENV
 
       - name: Import Apple certificate
         env:
@@ -313,7 +368,6 @@ jobs:
           ZOTERO_CONSUMER_KEY: ${{ secrets.ZOTERO_CONSUMER_KEY }}
           ZOTERO_CONSUMER_SECRET: ${{ secrets.ZOTERO_CONSUMER_SECRET }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          TECTONIC_DEP_BACKEND: pkg-config
         run: pnpm --filter @claude-prism/desktop tauri build --target x86_64-apple-darwin
 
       - name: Notarize DMG


### PR DESCRIPTION
## Summary
- Replace Homebrew (`brew install icu4c harfbuzz ...`) with **vcpkg** for both macOS builds (Apple Silicon + Intel)
- vcpkg's `arm64-osx` and `x64-osx` triplets default to **static linking** (`VCPKG_LIBRARY_LINKAGE static`)
- The built binary no longer depends on `/opt/homebrew` dylibs — only macOS system frameworks

## Problem
Users without Homebrew get a crash on launch (#77):
```
Library not loaded: /opt/homebrew/*/libicuuc.78.dylib
Reason: tried: '/opt/homebrew/*/libicuuc.78.dylib' (no such file)
```

## Root cause
Homebrew only ships `.dylib` (shared) libraries. The linker picks them up, and the resulting binary references absolute paths under `/opt/homebrew/`.

## Fix
Switch to vcpkg (which Windows already uses), providing `.a` (static) archives that get linked into the binary at build time.

## References
- [Building Tectonic — vcpkg backend](https://tectonic-typesetting.github.io/book/latest/howto/build-tectonic/)
- [vcpkg Triplets — static by default on macOS](https://learn.microsoft.com/en-us/vcpkg/users/triplets)
- [Homebrew does not ship static libraries](https://github.com/orgs/Homebrew/discussions/4672)
- [tectonic Cargo.toml — vcpkg metadata for macOS](https://github.com/tectonic-typesetting/tectonic/blob/master/Cargo.toml)

## Test plan
- [ ] CI build succeeds for `build-macos` (arm64-osx vcpkg)
- [ ] CI build succeeds for `build-macos-intel` (x64-osx vcpkg)
- [ ] `otool -L` on the built binary shows no `/opt/homebrew` references
- [ ] App launches on a Mac without Homebrew installed

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)