### PR TITLE
feat: UI improvements — collapsible sidebar, toolbar overflow, compilation logs

### DIFF
--- a/apps/desktop/src-tauri/src/latex.rs
+++ b/apps/desktop/src-tauri/src/latex.rs
@@ -694,6 +694,23 @@ pub async fn synctex_edit(
     Ok(SynctexResult { file, line, column })
 }
 
+#[tauri::command]
+pub async fn get_build_log(
+    state: tauri::State<'_, LatexCompilerState>,
+    project_dir: String,
+) -> Result<String, String> {
+    let builds = state.last_builds.lock().await;
+    let build = builds
+        .get(&project_dir)
+        .ok_or("No build found for this project")?;
+    let log_path = build
+        .work_dir
+        .join(format!("{}.log", build.main_file_name));
+    drop(builds);
+    std::fs::read_to_string(&log_path)
+        .map_err(|e| format!("Failed to read log: {e}"))
+}
+
 /// Clear in-memory build state on app exit.
 /// Persistent build directories are intentionally kept for fast restart.
 pub async fn cleanup_all_builds(state: &LatexCompilerState) {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -335,6 +335,7 @@ pub fn run() {
             read_clipboard_file_paths,
             latex::compile_latex,
             latex::synctex_edit,
+            latex::get_build_log,
             claude::check_claude_status,
             claude::install_claude_cli,
             claude::login_claude,

--- a/apps/desktop/src/components/scientific-skills/scientific-skills-onboarding.tsx
+++ b/apps/desktop/src/components/scientific-skills/scientific-skills-onboarding.tsx
@@ -62,6 +62,7 @@ export function ScientificSkillsOnboarding({
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<SkillsStatus | null>(null);
   const [isUninstalling, setIsUninstalling] = useState(false);
+  const [dontShowAgain, setDontShowAgain] = useState(false);
 
   // Check global install status
   const checkStatus = useCallback(async () => {
@@ -323,13 +324,31 @@ export function ScientificSkillsOnboarding({
 
         {/* Footer */}
         <div className="flex shrink-0 items-center justify-between border-border border-t bg-muted/20 px-6 py-2.5">
-          <p className="font-mono text-[11px] text-muted-foreground/60">
-            {isInstalled ? status?.location : "~/.claude/skills/"}
-          </p>
+          {!isInstalled ? (
+            <label className="flex cursor-pointer items-center gap-1.5">
+              <input
+                type="checkbox"
+                checked={dontShowAgain}
+                onChange={(e) => setDontShowAgain(e.target.checked)}
+              />
+              <span className="text-muted-foreground text-xs">
+                Don't show again
+              </span>
+            </label>
+          ) : (
+            <p className="font-mono text-[11px] text-muted-foreground/60">
+              {status?.location}
+            </p>
+          )}
           <Button
             variant="ghost"
             size="sm"
-            onClick={onClose}
+            onClick={() => {
+              if (dontShowAgain) {
+                localStorage.setItem(STORAGE_KEY, "true");
+              }
+              onClose();
+            }}
             className="text-muted-foreground"
           >
             Close

--- a/apps/desktop/src/components/workspace/editor/editor-toolbar.tsx
+++ b/apps/desktop/src/components/workspace/editor/editor-toolbar.tsx
@@ -16,6 +16,7 @@ import {
   PlusIcon,
   BookMarkedIcon,
   ExternalLinkIcon,
+  MoreHorizontalIcon,
 } from "lucide-react";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { Button } from "@/components/ui/button";
@@ -226,7 +227,7 @@ export function EditorToolbar({
   }
 
   return (
-    <div className="flex h-[calc(36px+var(--titlebar-height))] items-center gap-1 border-border border-b bg-muted/30 px-2 pt-[var(--titlebar-height)]">
+    <div className="@container/et flex h-[calc(36px+var(--titlebar-height))] items-center gap-1 border-border border-b bg-muted/30 px-2 pt-[var(--titlebar-height)]">
       <FileTextIcon className="size-4 text-muted-foreground" />
       <span className="mr-2 font-medium text-muted-foreground text-sm">
         {fileName}
@@ -250,45 +251,94 @@ export function EditorToolbar({
       >
         <CodeIcon className="size-4" />
       </TooltipIconButton>
-      <div className="mx-2 h-4 w-px bg-border" />
-      <TooltipIconButton
-        tooltip="Section"
-        onClick={() => insertText("\\section{", "}")}
-      >
-        <Heading1Icon className="size-4" />
-      </TooltipIconButton>
-      <TooltipIconButton
-        tooltip="Subsection"
-        onClick={() => insertText("\\subsection{", "}")}
-      >
-        <Heading2Icon className="size-4" />
-      </TooltipIconButton>
-      <TooltipIconButton
-        tooltip="List item"
-        onClick={() => insertText("\\item ")}
-      >
-        <ListIcon className="size-4" />
-      </TooltipIconButton>
-      <div className="mx-2 h-4 w-px bg-border" />
-      <TooltipIconButton
-        tooltip="Inline math ($...$)"
-        onClick={() => wrapSelection("$")}
-      >
-        <FunctionSquareIcon className="size-4" />
-      </TooltipIconButton>
-      <TooltipIconButton
-        tooltip="Display math (\\[...\\])"
-        onClick={() => insertText("\\[\n  ", "\n\\]")}
-      >
-        <span className="font-mono text-xs">∫</span>
-      </TooltipIconButton>
-      <div className="mx-2 h-4 w-px bg-border" />
-      <TooltipIconButton
-        tooltip="Citation (\\cite)"
-        onClick={() => insertText("\\cite{", "}")}
-      >
-        <BookMarkedIcon className="size-4" />
-      </TooltipIconButton>
+      {/* Responsive: show inline when wide, hide when narrow */}
+      <div className="@[32rem]/et:contents hidden">
+        <div className="mx-2 h-4 w-px bg-border" />
+        <TooltipIconButton
+          tooltip="Section"
+          onClick={() => insertText("\\section{", "}")}
+        >
+          <Heading1Icon className="size-4" />
+        </TooltipIconButton>
+        <TooltipIconButton
+          tooltip="Subsection"
+          onClick={() => insertText("\\subsection{", "}")}
+        >
+          <Heading2Icon className="size-4" />
+        </TooltipIconButton>
+        <TooltipIconButton
+          tooltip="List item"
+          onClick={() => insertText("\\item ")}
+        >
+          <ListIcon className="size-4" />
+        </TooltipIconButton>
+        <div className="mx-2 h-4 w-px bg-border" />
+        <TooltipIconButton
+          tooltip="Inline math ($...$)"
+          onClick={() => wrapSelection("$")}
+        >
+          <FunctionSquareIcon className="size-4" />
+        </TooltipIconButton>
+        <TooltipIconButton
+          tooltip="Display math (\\[...\\])"
+          onClick={() => insertText("\\[\n  ", "\n\\]")}
+        >
+          <span className="font-mono text-xs">∫</span>
+        </TooltipIconButton>
+        <div className="mx-2 h-4 w-px bg-border" />
+        <TooltipIconButton
+          tooltip="Citation (\\cite)"
+          onClick={() => insertText("\\cite{", "}")}
+        >
+          <BookMarkedIcon className="size-4" />
+        </TooltipIconButton>
+      </div>
+      {/* Overflow menu: visible only when narrow */}
+      <div className="@[32rem]/et:hidden">
+        <div className="flex items-center gap-1">
+          <div className="mx-2 h-4 w-px bg-border" />
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7 p-1"
+                title="More formatting"
+              >
+                <MoreHorizontalIcon className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuItem onClick={() => insertText("\\section{", "}")}>
+                <Heading1Icon className="mr-2 size-4" />
+                Section
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => insertText("\\subsection{", "}")}
+              >
+                <Heading2Icon className="mr-2 size-4" />
+                Subsection
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => insertText("\\item ")}>
+                <ListIcon className="mr-2 size-4" />
+                List Item
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => wrapSelection("$")}>
+                <FunctionSquareIcon className="mr-2 size-4" />
+                Inline Math
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => insertText("\\[\n  ", "\n\\]")}>
+                <span className="mr-2 font-mono text-xs">∫</span>
+                Display Math
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => insertText("\\cite{", "}")}>
+                <BookMarkedIcon className="mr-2 size-4" />
+                Citation
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
       <div data-tauri-drag-region className="flex-1 self-stretch" />
       {editors.length === 1 && (
         <TooltipIconButton

--- a/apps/desktop/src/components/workspace/preview/pdf-preview.tsx
+++ b/apps/desktop/src/components/workspace/preview/pdf-preview.tsx
@@ -13,9 +13,12 @@ import {
   CrosshairIcon,
   ChevronUpIcon,
   ChevronDownIcon,
+  MoreHorizontalIcon,
+  FileWarningIcon,
 } from "lucide-react";
 import { writeFile, mkdir, exists } from "@tauri-apps/plugin-fs";
 import { join } from "@tauri-apps/api/path";
+import { invoke } from "@tauri-apps/api/core";
 import {
   useDocumentStore,
   getPdfBytes,
@@ -40,6 +43,19 @@ import {
 } from "@/components/ui/popover";
 import { HistoryPanel } from "@/components/workspace/history-panel";
 import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
   compileLatex,
   synctexEdit,
   resolveCompileTarget,
@@ -60,6 +76,109 @@ import { resolveTexRoot } from "@/stores/document-store";
 import { createLogger } from "@/lib/debug/logger";
 
 const log = createLogger("pdf-preview");
+
+/** Classify a LaTeX log line for syntax highlighting. */
+function classifyLogLine(line: string): "error" | "warning" | "success" | null {
+  if (line.startsWith("!") || /\berror:/i.test(line) || /^l\.\d+/.test(line)) {
+    return "error";
+  }
+  if (
+    /Warning:/i.test(line) ||
+    /^Invalid UTF-8/i.test(line) ||
+    /undefined/i.test(line) ||
+    /Rerun to get/i.test(line) ||
+    /Overfull/i.test(line) ||
+    /Underfull/i.test(line)
+  ) {
+    return "warning";
+  }
+  if (/^Output written on/i.test(line) || /^\[\d+/.test(line)) {
+    return "success";
+  }
+  return null;
+}
+
+const LOG_LINE_STYLES: Record<string, string> = {
+  error:
+    "text-destructive font-semibold bg-destructive/10 rounded px-1 -mx-1 block",
+  warning:
+    "text-yellow-700 dark:text-yellow-300 bg-yellow-500/10 rounded px-1 -mx-1 block",
+  success:
+    "text-green-700 dark:text-green-300 bg-green-500/10 rounded px-1 -mx-1 block",
+};
+
+type WarningCategory = "font" | "reference" | "box" | "other";
+
+function categorizeWarningLine(line: string): WarningCategory | null {
+  if (/Font/i.test(line)) return "font";
+  if (/Reference|Citation|Rerun to get/i.test(line)) return "reference";
+  if (/Overfull|Underfull/i.test(line)) return "box";
+  if (
+    /Warning:/i.test(line) ||
+    /^Invalid UTF-8/i.test(line) ||
+    /undefined/i.test(line)
+  ) {
+    return "other";
+  }
+  return null;
+}
+
+interface LogSummary {
+  errors: number;
+  warnings: number;
+  font: number;
+  reference: number;
+  box: number;
+  other: number;
+}
+
+function summarizeLog(content: string): LogSummary {
+  const summary: LogSummary = {
+    errors: 0,
+    warnings: 0,
+    font: 0,
+    reference: 0,
+    box: 0,
+    other: 0,
+  };
+  for (const line of content.split("\n")) {
+    const cls = classifyLogLine(line);
+    if (cls === "error") {
+      summary.errors++;
+    } else if (cls === "warning") {
+      summary.warnings++;
+      const cat = categorizeWarningLine(line);
+      if (cat) summary[cat]++;
+    }
+  }
+  return summary;
+}
+
+function formatSummaryDetail(summary: LogSummary): string {
+  const parts: string[] = [];
+  if (summary.font > 0) parts.push(`${summary.font} font`);
+  if (summary.reference > 0) parts.push(`${summary.reference} reference`);
+  if (summary.box > 0) parts.push(`${summary.box} box`);
+  if (summary.other > 0) parts.push(`${summary.other} other`);
+  return parts.length > 0 ? ` (${parts.join(", ")})` : "";
+}
+
+function HighlightedLog({ content }: { content: string }) {
+  const lines = content.split("\n");
+  return (
+    <pre className="whitespace-pre-wrap p-4 font-mono text-foreground/50 text-xs leading-relaxed">
+      {lines.map((line, i) => {
+        const cls = classifyLogLine(line);
+        return (
+          <span key={i} className={cls ? LOG_LINE_STYLES[cls] : undefined}>
+            {line}
+            {"\n"}
+          </span>
+        );
+      })}
+    </pre>
+  );
+}
 
 type FitMode = "fit-width" | "fit-height" | null;
 
@@ -126,6 +245,10 @@ export function PdfPreview() {
   } | null>(null);
   const hasInitialCompile = useRef(false);
   const initialized = useDocumentStore((s) => s.initialized);
+  const [showLogs, setShowLogs] = useState(false);
+  const [logContent, setLogContent] = useState<string | null>(null);
+  const [logSummary, setLogSummary] = useState<LogSummary | null>(null);
+  const [showHistoryDialog, setShowHistoryDialog] = useState(false);
 
   // Derive pdfData from external cache, re-read whenever pdfRevision bumps
   const pdfData = useMemo(() => getCurrentPdfBytes(), [pdfRevision]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -396,6 +519,19 @@ export function PdfPreview() {
     return { top: relTop, left: relLeft };
   })();
 
+  const fetchLogSummary = useCallback(async () => {
+    if (!projectRoot) return;
+    try {
+      const content = await invoke<string>("get_build_log", {
+        projectDir: projectRoot,
+      });
+      setLogContent(content);
+      setLogSummary(summarizeLog(content));
+    } catch {
+      setLogSummary(null);
+    }
+  }, [projectRoot]);
+
   useEffect(() => {
     if (hasInitialCompile.current) return;
     if (!initialized || !projectRoot) return;
@@ -422,11 +558,13 @@ export function PdfPreview() {
         setCompileError(formatCompileError(error));
       } finally {
         setIsCompiling(false);
+        fetchLogSummary();
       }
     };
     compile();
   }, [
     initialized,
+    fetchLogSummary,
     projectRoot,
     pdfData,
     isCompiling,
@@ -477,6 +615,11 @@ export function PdfPreview() {
     });
     if (!filePath) return;
     await writeFile(filePath, new Uint8Array(currentPdf));
+  };
+
+  const handleOpenLogs = async () => {
+    await fetchLogSummary();
+    setShowLogs(true);
   };
 
   const handleCurrentPageChange = useCallback(
@@ -564,6 +707,7 @@ export function PdfPreview() {
         await new Promise((r) => setTimeout(r, 500 - elapsed));
       }
       setIsCompiling(false);
+      fetchLogSummary();
       // If a recompile was requested while we were compiling, trigger it now
       // Use setTimeout to avoid unbounded recursion on the call stack
       if (useDocumentStore.getState().pendingRecompile) {
@@ -835,6 +979,27 @@ export function PdfPreview() {
               Retry
             </Button>
           )}
+          {!isSaving &&
+            !isCompiling &&
+            logSummary &&
+            (logSummary.warnings > 0 || logSummary.errors > 0) && (
+              <button
+                onClick={handleOpenLogs}
+                className={`flex items-center gap-0.5 rounded-md px-1.5 py-0.5 transition-colors ${
+                  logSummary.errors > 0
+                    ? "bg-destructive/15 text-destructive hover:bg-destructive/25"
+                    : "bg-yellow-500/15 text-yellow-700 hover:bg-yellow-500/25 dark:text-yellow-300"
+                }`}
+                title="Open compilation logs"
+              >
+                <AlertCircleIcon className="size-3" />
+                <span className="font-medium text-[11px] tabular-nums">
+                  {logSummary.errors > 0
+                    ? logSummary.errors
+                    : logSummary.warnings}
+                </span>
+              </button>
+            )}
         </div>
         <div data-tauri-drag-region className="flex-1 self-stretch" />
         <div className="flex shrink-0 items-center gap-1">
@@ -961,32 +1126,69 @@ export function PdfPreview() {
                 </kbd>
               </Button>
               <div className="mx-1 h-4 w-px bg-border" />
+              {/* Export, Logs, History: inline when wide */}
               <Button
                 variant="ghost"
                 size="icon"
-                className="size-7"
+                className="@[40rem]/pv:flex hidden size-7"
                 onClick={handleExport}
                 title="Export PDF"
               >
                 <DownloadIcon className="size-3.5" />
               </Button>
-            </>
-          )}
-          <Popover>
-            <PopoverTrigger asChild>
               <Button
                 variant="ghost"
                 size="icon"
-                className="size-7"
-                title="History"
+                className="@[40rem]/pv:flex hidden size-7"
+                onClick={handleOpenLogs}
+                title="Compilation Logs"
               >
-                <HistoryIcon className="size-3.5" />
+                <FileWarningIcon className="size-3.5" />
               </Button>
-            </PopoverTrigger>
-            <PopoverContent align="end" className="w-96">
-              <HistoryPanel maxHeight="max-h-[32rem]" />
-            </PopoverContent>
-          </Popover>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="@[40rem]/pv:flex hidden size-7"
+                    title="History"
+                  >
+                    <HistoryIcon className="size-3.5" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent align="end" className="w-96">
+                  <HistoryPanel maxHeight="max-h-[32rem]" />
+                </PopoverContent>
+              </Popover>
+              {/* Overflow menu: visible only when narrow */}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="@[40rem]/pv:hidden size-7"
+                    title="More actions"
+                  >
+                    <MoreHorizontalIcon className="size-3.5" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onClick={handleExport}>
+                    <DownloadIcon className="mr-2 size-4" />
+                    Export PDF
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={handleOpenLogs}>
+                    <FileWarningIcon className="mr-2 size-4" />
+                    Compilation Logs
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => setShowHistoryDialog(true)}>
+                    <HistoryIcon className="mr-2 size-4" />
+                    History
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </>
+          )}
         </div>
       </div>
       {renderContent()}
@@ -1020,6 +1222,87 @@ export function PdfPreview() {
           </div>
         </div>
       )}
+      {/* History Dialog (used when in overflow mode) */}
+      <Dialog open={showHistoryDialog} onOpenChange={setShowHistoryDialog}>
+        <DialogContent className="flex h-[min(36rem,calc(100vh-6rem))] w-96 max-w-none flex-col gap-0 overflow-hidden p-0 sm:max-w-none">
+          <DialogHeader className="shrink-0 border-border border-b px-6 py-3">
+            <DialogTitle className="flex items-center gap-2 text-sm">
+              <HistoryIcon className="size-4 text-muted-foreground" />
+              History
+            </DialogTitle>
+          </DialogHeader>
+          <ScrollArea className="flex-1">
+            <HistoryPanel maxHeight="" />
+          </ScrollArea>
+        </DialogContent>
+      </Dialog>
+      {/* Compilation Logs Dialog */}
+      <Dialog open={showLogs} onOpenChange={setShowLogs}>
+        <DialogContent className="flex h-[min(36rem,calc(100vh-6rem))] w-[min(48rem,calc(100vw-4rem))] max-w-none flex-col gap-0 overflow-hidden p-0 sm:max-w-none">
+          <DialogHeader className="shrink-0 border-border border-b px-6 py-3">
+            <DialogTitle className="flex items-center gap-2 text-sm">
+              <FileWarningIcon className="size-4 text-muted-foreground" />
+              Compilation Logs
+            </DialogTitle>
+          </DialogHeader>
+          {logContent &&
+            (() => {
+              const summary = summarizeLog(logContent);
+              if (summary.errors === 0 && summary.warnings === 0) return null;
+              return (
+                <div className="flex shrink-0 items-center gap-3 border-border border-b bg-muted/30 px-6 py-2">
+                  <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2 text-xs">
+                    {summary.errors > 0 && (
+                      <span className="rounded-md bg-destructive/15 px-2 py-0.5 font-medium text-destructive">
+                        {summary.errors}{" "}
+                        {summary.errors === 1 ? "error" : "errors"}
+                      </span>
+                    )}
+                    {summary.warnings > 0 && (
+                      <span className="rounded-md bg-yellow-500/15 px-2 py-0.5 font-medium text-yellow-700 dark:text-yellow-300">
+                        {summary.warnings}{" "}
+                        {summary.warnings === 1 ? "warning" : "warnings"}
+                        {formatSummaryDetail(summary)}
+                      </span>
+                    )}
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 shrink-0 gap-1.5 text-xs"
+                    onClick={() => {
+                      setShowLogs(false);
+                      const lines = logContent
+                        .split("\n")
+                        .filter((l) => classifyLogLine(l) !== null);
+                      const excerpt =
+                        lines.length > 30
+                          ? `${lines.slice(0, 30).join("\n")}\n... (${lines.length - 30} more)`
+                          : lines.join("\n");
+                      useClaudeChatStore
+                        .getState()
+                        .sendPrompt(
+                          `[Compilation log — ${summary.errors} errors, ${summary.warnings} warnings]\n${excerpt}\n\nExplain these issues and suggest fixes.`,
+                        );
+                    }}
+                  >
+                    <MousePointerClickIcon className="size-3.5" />
+                    Ask AI about these
+                  </Button>
+                </div>
+              );
+            })()}
+          <ScrollArea className="flex-1">
+            {logContent ? (
+              <HighlightedLog content={logContent} />
+            ) : (
+              <pre className="whitespace-pre-wrap p-4 font-mono text-foreground/50 text-xs leading-relaxed">
+                No log available.
+              </pre>
+            )}
+          </ScrollArea>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/apps/desktop/src/components/workspace/sidebar.tsx
+++ b/apps/desktop/src/components/workspace/sidebar.tsx
@@ -25,6 +25,8 @@ import {
   AppWindowIcon,
   FlaskConicalIcon,
   TerminalIcon,
+  SettingsIcon,
+  PanelLeftCloseIcon,
 } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import {
@@ -58,6 +60,7 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  DropdownMenuCheckboxItem,
 } from "@/components/ui/dropdown-menu";
 import {
   ContextMenu,
@@ -71,6 +74,8 @@ import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useUvSetupStore } from "@/stores/uv-setup-store";
 import { UvSetupDialog } from "@/components/uv-setup";
+import { useUiPreferencesStore } from "@/stores/ui-preferences-store";
+import { resetOnboardingFlag } from "@/components/scientific-skills/scientific-skills-onboarding";
 import { createLogger } from "@/lib/debug/logger";
 
 const log = createLogger("sidebar");
@@ -206,7 +211,11 @@ function useAppVersion() {
 
 // ─── Sidebar ───
 
-export function Sidebar() {
+interface SidebarProps {
+  onToggleSidebar?: () => void;
+}
+
+export function Sidebar({ onToggleSidebar }: SidebarProps = {}) {
   const appVersion = useAppVersion();
   const files = useDocumentStore((s) => s.files);
   const activeFileId = useDocumentStore((s) => s.activeFileId);
@@ -232,6 +241,8 @@ export function Sidebar() {
   const projectRoot = useDocumentStore((s) => s.projectRoot);
   const folders = useDocumentStore((s) => s.folders);
   const { theme, setTheme } = useTheme();
+  const showZotero = useUiPreferencesStore((s) => s.showZoteroPanel);
+  const setShowZotero = useUiPreferencesStore((s) => s.setShowZoteroPanel);
 
   // ─── Native OS file drop (Tauri onDragDropEvent) ───
   const sidebarFilesRef = useRef<HTMLDivElement>(null);
@@ -638,6 +649,17 @@ export function Sidebar() {
           >
             <HomeIcon className="size-3.5" />
           </Button>
+          {onToggleSidebar && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-6"
+              onClick={onToggleSidebar}
+              title="Collapse Sidebar"
+            >
+              <PanelLeftCloseIcon className="size-3.5" />
+            </Button>
+          )}
         </div>
       </div>
 
@@ -792,19 +814,23 @@ export function Sidebar() {
           </div>
         </Panel>
 
-        <PanelResizeHandle className="h-px bg-sidebar-border transition-colors hover:bg-ring data-resize-handle-active:bg-ring" />
+        {showZotero && (
+          <>
+            <PanelResizeHandle className="h-px bg-sidebar-border transition-colors hover:bg-ring data-resize-handle-active:bg-ring" />
 
-        {/* Zotero */}
-        <Panel defaultSize={15} minSize={10}>
-          <div className="flex h-full flex-col">
-            <div className="flex h-8 shrink-0 items-center">
-              <ZoteroHeader />
-            </div>
-            <div className="min-h-0 flex-1 overflow-hidden">
-              <ZoteroPanel />
-            </div>
-          </div>
-        </Panel>
+            {/* Zotero */}
+            <Panel defaultSize={15} minSize={10}>
+              <div className="flex h-full flex-col">
+                <div className="flex h-8 shrink-0 items-center">
+                  <ZoteroHeader />
+                </div>
+                <div className="min-h-0 flex-1 overflow-hidden">
+                  <ZoteroPanel />
+                </div>
+              </div>
+            </Panel>
+          </>
+        )}
       </PanelGroup>
 
       {/* Environment section — Python + Skills */}
@@ -849,6 +875,35 @@ export function Sidebar() {
               <MoonIcon className="size-3.5" />
             )}
           </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-6"
+                title="Settings"
+              >
+                <SettingsIcon className="size-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" side="top">
+              <DropdownMenuCheckboxItem
+                checked={showZotero}
+                onCheckedChange={setShowZotero}
+              >
+                Show Zotero Panel
+              </DropdownMenuCheckboxItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={() => {
+                  setShowZotero(true);
+                  resetOnboardingFlag();
+                }}
+              >
+                Revert to Defaults
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </div>
 

--- a/apps/desktop/src/components/workspace/workspace-layout.tsx
+++ b/apps/desktop/src/components/workspace/workspace-layout.tsx
@@ -1,11 +1,31 @@
-import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
+import { useCallback, useRef, useState } from "react";
+import {
+  Panel,
+  PanelGroup,
+  PanelResizeHandle,
+  type ImperativePanelHandle,
+} from "react-resizable-panels";
+import { PanelLeftOpenIcon } from "lucide-react";
 import { Sidebar } from "./sidebar";
 import { LatexEditor } from "./editor/latex-editor";
 import { PdfPreview } from "./preview/pdf-preview";
 import { useDocumentStore } from "@/stores/document-store";
+import { Button } from "@/components/ui/button";
 
 export function WorkspaceLayout() {
   const initialized = useDocumentStore((s) => s.initialized);
+  const sidebarRef = useRef<ImperativePanelHandle>(null);
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+
+  const toggleSidebar = useCallback(() => {
+    const panel = sidebarRef.current;
+    if (!panel) return;
+    if (panel.isCollapsed()) {
+      panel.expand();
+    } else {
+      panel.collapse();
+    }
+  }, []);
 
   if (!initialized) {
     return (
@@ -17,14 +37,38 @@ export function WorkspaceLayout() {
 
   return (
     <PanelGroup direction="horizontal" className="h-full">
-      <Panel defaultSize={15} minSize={10} maxSize={25}>
-        <Sidebar />
+      <Panel
+        ref={sidebarRef}
+        defaultSize={15}
+        minSize={10}
+        maxSize={25}
+        collapsible
+        collapsedSize={0}
+        onCollapse={() => setIsSidebarCollapsed(true)}
+        onExpand={() => setIsSidebarCollapsed(false)}
+      >
+        <Sidebar onToggleSidebar={toggleSidebar} />
       </Panel>
 
       <PanelResizeHandle className="w-px bg-border transition-colors hover:bg-ring" />
 
       <Panel defaultSize={42.5} minSize={25}>
-        <LatexEditor />
+        <div className="relative h-full">
+          {isSidebarCollapsed && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="absolute top-[calc(var(--titlebar-height)+6px)] left-1 z-10 size-6"
+              onClick={toggleSidebar}
+              title="Expand Sidebar"
+            >
+              <PanelLeftOpenIcon className="size-3.5" />
+            </Button>
+          )}
+          <div className={isSidebarCollapsed ? "h-full pl-7" : "h-full"}>
+            <LatexEditor />
+          </div>
+        </div>
       </Panel>
 
       <PanelResizeHandle className="w-px bg-border transition-colors hover:bg-ring" />

--- a/apps/desktop/src/stores/ui-preferences-store.ts
+++ b/apps/desktop/src/stores/ui-preferences-store.ts
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface UiPreferencesState {
+  showZoteroPanel: boolean;
+  setShowZoteroPanel: (show: boolean) => void;
+}
+
+export const useUiPreferencesStore = create<UiPreferencesState>()(
+  persist(
+    (set) => ({
+      showZoteroPanel: true,
+      setShowZoteroPanel: (show) => set({ showZoteroPanel: show }),
+    }),
+    {
+      name: "claude-prism-ui-preferences",
+    },
+  ),
+);


### PR DESCRIPTION
## Summary

- **Skills onboarding "Don't show again"** — checkbox in the footer lets users dismiss the overlay permanently without installing all 148 skills
- **Collapsible sidebar** — toggle buttons to collapse/expand the sidebar, giving more space to editor + PDF preview
- **Hideable Zotero panel** — settings gear in the sidebar footer with a checkbox to toggle Zotero visibility (persisted via Zustand store), plus "Revert to Defaults"
- **Responsive editor toolbar** — Bold/Italic/Code always visible; Section, Subsection, List Item, Math, Citation collapse into an overflow menu when the panel is narrow
- **Responsive PDF toolbar** — Export PDF, Compilation Logs, and History collapse into an overflow menu when narrow; History opens as a dialog from overflow
- **Compilation logs viewer** — new `get_build_log` Tauri command + dialog with syntax highlighting (errors red, warnings amber, success green, noise dimmed), categorized summary bar, and "Ask AI about these" button
- **Warning pill** — amber/red indicator next to the compile button showing issue count after each compilation, clickable to open logs

## Test plan

All steps verified locally on macOS:

- [x] App starts and compiles documents
- [x] Skills onboarding: check "Don't show again", close, reopen — overlay does not reappear
- [x] Collapse/expand sidebar via both toggle buttons
- [x] Toggle Zotero panel via settings gear menu
- [x] "Revert to Defaults" resets Zotero visibility and skills dismissal
- [x] Narrow the editor panel — toolbar items collapse into overflow menu
- [x] Narrow the PDF panel — Export/Logs/History collapse into overflow menu
- [x] Compile a document — warning pill appears with count
- [x] Introduce a LaTeX error, compile — pill turns red, logs show error highlighting
- [x] Click pill or Logs button — dialog shows highlighted log with summary
- [x] Click "Ask AI about these" — sends filtered issues to Claude chat
- [x] `pnpm lint` — 0 errors
- [x] `pnpm test` (frontend) — 140/140 pass
- [x] `cargo test` (Rust) — 146/146 pass

Note: Linux and Windows not yet tested.