### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-prism/desktop",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-prism-desktop"
-version = "1.0.10"
+version = "1.1.0"
 description = "AI-powered LaTeX writing workspace"
 edition = "2021"
 

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/nicegui-unofficial/nicegui-tauri-template/main/src-tauri/tauri.conf-v2-schema.json",
   "identifier": "com.claude-prism.desktop",
   "productName": "ClaudePrism",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@claude-prism/root",
   "description": "Open-Source AI LaTeX writing workspace",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/delibae/claude-prism"


### PR DESCRIPTION
## Summary
- Bump version from 1.0.10 to 1.1.0 across all manifests (package.json, tauri.conf.json, Cargo.toml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)