### PR TITLE
fix: skip Python cache files during project scan

### DIFF
--- a/apps/desktop/src/__tests__/lib/tauri-fs.test.ts
+++ b/apps/desktop/src/__tests__/lib/tauri-fs.test.ts
@@ -1,173 +1,103 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { readDir, stat } from "@tauri-apps/plugin-fs";
+import {
+  getProjectFileType,
+  scanProjectFolder,
+  shouldSkipProjectDirectory,
+} from "@/lib/tauri/fs";
 
-// getFileType is not exported, so we test via the module's behavior.
-// We need to import from the source and test the classification logic.
-// Since getFileType is private, we'll extract the logic into a testable pattern.
-// For now, test the exported types and the classification indirectly.
-
-// We can test the file type classification logic by reimplementing the same
-// pattern as the source and verifying consistency, or we test via scanProjectFolder.
-// Since scanProjectFolder requires Tauri filesystem mocks with complex async behavior,
-// let's test the pure classification logic directly by accessing the private function
-// via a small wrapper test.
-
-// Actually, the simplest approach: the getFileType function is module-private.
-// We'll test it by examining the constants and logic as documented.
-
-describe("getFileType logic", () => {
-  // Replicate the classification logic for testing
-  const IMAGE_EXTENSIONS = new Set([
-    ".png",
-    ".jpg",
-    ".jpeg",
-    ".gif",
-    ".svg",
-    ".bmp",
-    ".webp",
-  ]);
-  const STYLE_EXTENSIONS = new Set([
-    ".sty",
-    ".cls",
-    ".bst",
-    ".def",
-    ".cfg",
-    ".fd",
-    ".dtx",
-    ".ins",
-  ]);
-  const IGNORED_EXTENSIONS = new Set([
-    ".aux",
-    ".log",
-    ".out",
-    ".toc",
-    ".lof",
-    ".lot",
-    ".fls",
-    ".fdb_latexmk",
-    ".synctex.gz",
-    ".synctex",
-    ".blg",
-    ".bbl",
-    ".nav",
-    ".snm",
-    ".vrb",
-    ".run.xml",
-    ".bcf",
-    // Binary / non-text files
-    ".hwp",
-    ".hwpx",
-    ".doc",
-    ".docx",
-    ".xls",
-    ".xlsx",
-    ".xlsm",
-    ".ppt",
-    ".pptx",
-    ".accdb",
-    ".mdb",
-    ".zip",
-    ".rar",
-    ".7z",
-    ".tar",
-    ".gz",
-    ".exe",
-    ".dll",
-    ".so",
-    ".dylib",
-    ".o",
-    ".obj",
-    ".bin",
-    ".dat",
-    ".iso",
-    ".dmg",
-    ".msi",
-    ".mp3",
-    ".mp4",
-    ".avi",
-    ".mov",
-    ".mkv",
-    ".wav",
-    ".flac",
-    ".psd",
-    ".ai",
-    ".sketch",
-    ".fig",
-    ".sqlite",
-    ".db",
-  ]);
-
-  function getFileType(name: string): string | null {
-    const lower = name.toLowerCase();
-    for (const ext of IGNORED_EXTENSIONS) {
-      if (lower.endsWith(ext)) return null;
-    }
-    if (lower.endsWith(".tex") || lower.endsWith(".ltx")) return "tex";
-    if (lower.endsWith(".bib")) return "bib";
-    if (lower.endsWith(".pdf")) return "pdf";
-    for (const ext of IMAGE_EXTENSIONS) {
-      if (lower.endsWith(ext)) return "image";
-    }
-    for (const ext of STYLE_EXTENSIONS) {
-      if (lower.endsWith(ext)) return "style";
-    }
-    return "other";
-  }
-
-  it("classifies .tex files", () => {
-    expect(getFileType("main.tex")).toBe("tex");
-    expect(getFileType("chapter.TEX")).toBe("tex");
-    expect(getFileType("doc.ltx")).toBe("tex");
+describe("tauri fs helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
-  it("classifies .bib files", () => {
-    expect(getFileType("refs.bib")).toBe("bib");
+  describe("getProjectFileType", () => {
+    it("classifies editable project files", () => {
+      expect(getProjectFileType("main.tex")).toBe("tex");
+      expect(getProjectFileType("chapter.TEX")).toBe("tex");
+      expect(getProjectFileType("refs.bib")).toBe("bib");
+      expect(getProjectFileType("output.pdf")).toBe("pdf");
+      expect(getProjectFileType("figure.png")).toBe("image");
+      expect(getProjectFileType("custom.sty")).toBe("style");
+      expect(getProjectFileType("notes.md")).toBe("other");
+      expect(getProjectFileType("script.py")).toBe("other");
+    });
+
+    it("ignores generated and binary file types", () => {
+      expect(getProjectFileType("main.aux")).toBeNull();
+      expect(getProjectFileType("main.synctex.gz")).toBeNull();
+      expect(getProjectFileType("archive.zip")).toBeNull();
+      expect(getProjectFileType("module.pyc")).toBeNull();
+      expect(getProjectFileType("module.PYO")).toBeNull();
+      expect(getProjectFileType("native.pyd")).toBeNull();
+    });
   });
 
-  it("classifies .pdf files", () => {
-    expect(getFileType("output.pdf")).toBe("pdf");
+  describe("shouldSkipProjectDirectory", () => {
+    it("skips hidden and generated dependency directories", () => {
+      expect(shouldSkipProjectDirectory(".git")).toBe(true);
+      expect(shouldSkipProjectDirectory(".venv")).toBe(true);
+      expect(shouldSkipProjectDirectory("node_modules")).toBe(true);
+      expect(shouldSkipProjectDirectory("__pycache__")).toBe(true);
+      expect(shouldSkipProjectDirectory("venv")).toBe(true);
+      expect(shouldSkipProjectDirectory("ENV")).toBe(true);
+    });
+
+    it("keeps normal project folders visible", () => {
+      expect(shouldSkipProjectDirectory("chapters")).toBe(false);
+      expect(shouldSkipProjectDirectory("figures")).toBe(false);
+      expect(shouldSkipProjectDirectory("attachments")).toBe(false);
+    });
   });
 
-  it("classifies image files", () => {
-    expect(getFileType("fig.png")).toBe("image");
-    expect(getFileType("photo.jpg")).toBe("image");
-    expect(getFileType("icon.svg")).toBe("image");
-    expect(getFileType("anim.gif")).toBe("image");
-    expect(getFileType("pic.webp")).toBe("image");
-  });
+  describe("scanProjectFolder", () => {
+    it("does not recurse into generated cache directories", async () => {
+      vi.mocked(readDir).mockImplementation(async (dir: string) => {
+        if (dir === "/project") {
+          return [
+            { name: "__pycache__", isDirectory: true },
+            { name: "node_modules", isDirectory: true },
+            { name: "main.tex", isDirectory: false },
+            { name: "chapters", isDirectory: true },
+          ] as any;
+        }
 
-  it("classifies style files", () => {
-    expect(getFileType("custom.sty")).toBe("style");
-    expect(getFileType("report.cls")).toBe("style");
-    expect(getFileType("plain.bst")).toBe("style");
-  });
+        if (dir === "/project/chapters") {
+          return [{ name: "intro.tex", isDirectory: false }] as any;
+        }
 
-  it("ignores build artifacts", () => {
-    expect(getFileType("main.aux")).toBeNull();
-    expect(getFileType("main.log")).toBeNull();
-    expect(getFileType("main.toc")).toBeNull();
-    expect(getFileType("main.synctex.gz")).toBeNull();
-    expect(getFileType("main.fdb_latexmk")).toBeNull();
-    expect(getFileType("main.bbl")).toBeNull();
-  });
+        throw new Error(`Unexpected readDir path: ${dir}`);
+      });
 
-  it("ignores binary and non-text files", () => {
-    expect(getFileType("document.docx")).toBeNull();
-    expect(getFileType("spreadsheet.xlsx")).toBeNull();
-    expect(getFileType("report.hwp")).toBeNull();
-    expect(getFileType("data.accdb")).toBeNull();
-    expect(getFileType("archive.zip")).toBeNull();
-    expect(getFileType("app.exe")).toBeNull();
-    expect(getFileType("song.mp3")).toBeNull();
-    expect(getFileType("video.mp4")).toBeNull();
-    expect(getFileType("image.psd")).toBeNull();
-    expect(getFileType("database.sqlite")).toBeNull();
-    expect(getFileType("library.dll")).toBeNull();
-    expect(getFileType("presentation.pptx")).toBeNull();
-  });
+      const result = await scanProjectFolder("/project");
 
-  it("classifies unknown extensions as other", () => {
-    expect(getFileType("readme.txt")).toBe("other");
-    expect(getFileType("notes.md")).toBe("other");
-    expect(getFileType("data.csv")).toBe("other");
+      expect(readDir).toHaveBeenCalledWith("/project");
+      expect(readDir).toHaveBeenCalledWith("/project/chapters");
+      expect(readDir).not.toHaveBeenCalledWith("/project/__pycache__");
+      expect(readDir).not.toHaveBeenCalledWith("/project/node_modules");
+      expect(result.folders).toEqual(["chapters"]);
+      expect(result.files.map((file) => file.relativePath)).toEqual([
+        "main.tex",
+        "chapters/intro.tex",
+      ]);
+    });
+
+    it("filters bytecode files while keeping real source files", async () => {
+      vi.mocked(readDir).mockResolvedValue([
+        { name: "module.pyc", isDirectory: false },
+        { name: "worker.py", isDirectory: false },
+        { name: "notes.txt", isDirectory: false },
+      ] as any);
+      vi.mocked(stat).mockResolvedValue({ size: 128 } as any);
+
+      const result = await scanProjectFolder("/project");
+
+      expect(result.files.map((file) => file.relativePath)).toEqual([
+        "worker.py",
+        "notes.txt",
+      ]);
+      expect(stat).toHaveBeenCalledTimes(2);
+      expect(result.files.every((file) => file.type === "other")).toBe(true);
+    });
   });
 });

--- a/apps/desktop/src/__tests__/mocks/tauri.ts
+++ b/apps/desktop/src/__tests__/mocks/tauri.ts
@@ -59,6 +59,7 @@ vi.mock("@tauri-apps/plugin-fs", () => ({
   readTextFile: vi.fn(),
   writeTextFile: vi.fn(),
   readDir: vi.fn(),
+  stat: vi.fn(),
   exists: vi.fn(),
   mkdir: vi.fn(),
   readFile: vi.fn(),

--- a/apps/desktop/src/__tests__/stores/document-store.test.ts
+++ b/apps/desktop/src/__tests__/stores/document-store.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { invoke } from "@tauri-apps/api/core";
-import { readDir, readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
+import {
+  readDir,
+  readTextFile,
+  stat,
+  writeTextFile,
+} from "@tauri-apps/plugin-fs";
 import {
   useDocumentStore,
   getCurrentPdfBytes,
@@ -114,6 +119,44 @@ describe("useDocumentStore", () => {
       await openProjectPromise;
 
       expect(readDir).toHaveBeenCalled();
+    });
+
+    it("skips Python cache directories and bytecode files during open", async () => {
+      vi.mocked(invoke).mockResolvedValue(undefined as never);
+      vi.mocked(readDir).mockImplementation(async (dir: string) => {
+        if (dir === "/project") {
+          return [
+            { name: "__pycache__", isDirectory: true },
+            { name: "main.tex", isDirectory: false },
+            { name: "tool.py", isDirectory: false },
+            { name: "compiled.pyc", isDirectory: false },
+          ] as any;
+        }
+
+        throw new Error(`Unexpected readDir path: ${dir}`);
+      });
+      vi.mocked(stat).mockResolvedValue({ size: 32 } as any);
+      vi.mocked(readTextFile).mockImplementation(async (path: string) => {
+        if (path === "/project/main.tex") {
+          return "\\documentclass{article}";
+        }
+        if (path === "/project/tool.py") {
+          return "print('hello')";
+        }
+        throw new Error(`Unexpected readTextFile path: ${path}`);
+      });
+
+      await useDocumentStore.getState().openProject("/project");
+
+      expect(readDir).toHaveBeenCalledWith("/project");
+      expect(readDir).not.toHaveBeenCalledWith("/project/__pycache__");
+      expect(stat).toHaveBeenCalledTimes(1);
+      expect(stat).toHaveBeenCalledWith("/project/tool.py");
+      expect(readTextFile).toHaveBeenCalledTimes(2);
+      expect(readTextFile).not.toHaveBeenCalledWith("/project/compiled.pyc");
+      expect(
+        useDocumentStore.getState().files.map((file) => file.relativePath),
+      ).toEqual(["main.tex", "tool.py"]);
     });
   });
 

--- a/apps/desktop/src/lib/tauri/fs.ts
+++ b/apps/desktop/src/lib/tauri/fs.ts
@@ -55,6 +55,13 @@ const STYLE_EXTENSIONS = new Set([
   ".ins",
 ]);
 
+const IGNORED_DIRECTORY_NAMES = new Set([
+  "node_modules",
+  "__pycache__",
+  "venv",
+  "env",
+]);
+
 const IGNORED_EXTENSIONS = new Set([
   // Ignored file extensions: LaTeX build artifacts and other non-editable/binary files
   ".aux",
@@ -93,11 +100,14 @@ const IGNORED_EXTENSIONS = new Set([
   ".gz",
   ".exe",
   ".dll",
+  ".pyd",
   ".so",
   ".dylib",
   ".o",
   ".obj",
   ".bin",
+  ".pyc",
+  ".pyo",
   ".dat",
   ".iso",
   ".dmg",
@@ -117,7 +127,13 @@ const IGNORED_EXTENSIONS = new Set([
   ".db",
 ]);
 
-function getFileType(name: string): ProjectFileType | null {
+export function shouldSkipProjectDirectory(name: string): boolean {
+  return (
+    name.startsWith(".") || IGNORED_DIRECTORY_NAMES.has(name.toLowerCase())
+  );
+}
+
+export function getProjectFileType(name: string): ProjectFileType | null {
   const lower = name.toLowerCase();
   // Skip ignored file extensions (build artifacts, binary/non-text files)
   for (const ext of IGNORED_EXTENSIONS) {
@@ -153,13 +169,13 @@ export async function scanProjectFolder(rootPath: string): Promise<ScanResult> {
 
       if (entry.isDirectory) {
         // Skip hidden directories and common non-project dirs
-        if (entry.name.startsWith(".") || entry.name === "node_modules") {
+        if (shouldSkipProjectDirectory(entry.name)) {
           continue;
         }
         folders.push(relativePath);
         await walk(entryPath, relativePath);
       } else {
-        const type = getFileType(entry.name);
+        const type = getProjectFileType(entry.name);
         if (type) {
           // Only stat files that may be skipped by the large-file threshold
           // (image and other). tex/bib/style are always loaded, pdf is always lazy.


### PR DESCRIPTION
## Summary
- skip generated Python cache directories during project scans (`__pycache__`, plus existing hidden dirs / `node_modules` handling)
- ignore Python bytecode / native extension artifacts (`.pyc`, `.pyo`, `.pyd`) so they are not treated as editable project files
- add regression tests for both filesystem scanning and `openProject()` so Windows recent-project opens do not walk into cache trees again

## Why
On Windows, opening a recent project can become extremely slow when the project contains Python cache artifacts. ClaudePrism currently scans the entire project tree on open and preloads many small files. If `__pycache__` is included, this can multiply filesystem calls and trigger a lot of real-time antivirus scanning overhead.

This change keeps normal source files visible, but avoids descending into generated Python cache folders or indexing bytecode files that are not useful to edit in ClaudePrism.

## Testing
- `pnpm --dir apps/desktop test`
- `pnpm exec biome check apps/desktop/src/lib/tauri/fs.ts apps/desktop/src/__tests__/lib/tauri-fs.test.ts apps/desktop/src/__tests__/stores/document-store.test.ts apps/desktop/src/__tests__/mocks/tauri.ts`

## Notes
- `pnpm lint` still fails on the repository baseline because there are many pre-existing Biome formatting issues outside this PR's files.
