### PR TITLE
feat(workspace): toggle PDF preview pane with Cmd+\

### DIFF
--- a/apps/desktop/src/components/workspace/workspace-layout.tsx
+++ b/apps/desktop/src/components/workspace/workspace-layout.tsx
@@ -1,11 +1,28 @@
+import { useEffect } from "react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
+import { PanelRightCloseIcon, PanelRightOpenIcon } from "lucide-react";
 import { Sidebar } from "./sidebar";
 import { LatexEditor } from "./editor/latex-editor";
 import { PdfPreview } from "./preview/pdf-preview";
 import { useDocumentStore } from "@/stores/document-store";
+import { usePreviewStore } from "@/stores/preview-store";
 
 export function WorkspaceLayout() {
   const initialized = useDocumentStore((s) => s.initialized);
+  const previewVisible = usePreviewStore((s) => s.visible);
+  const togglePreview = usePreviewStore((s) => s.toggle);
+
+  // Cmd+\ / Ctrl+\ toggles the PDF preview pane.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "\\") {
+        e.preventDefault();
+        togglePreview();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [togglePreview]);
 
   if (!initialized) {
     return (
@@ -23,15 +40,37 @@ export function WorkspaceLayout() {
 
       <PanelResizeHandle className="w-px bg-border transition-colors hover:bg-ring" />
 
-      <Panel defaultSize={42.5} minSize={25}>
-        <LatexEditor />
+      <Panel defaultSize={previewVisible ? 42.5 : 85} minSize={25}>
+        <div className="relative h-full">
+          <LatexEditor />
+          <button
+            type="button"
+            onClick={togglePreview}
+            title={
+              previewVisible
+                ? "Hide PDF preview (Cmd+\\)"
+                : "Show PDF preview (Cmd+\\)"
+            }
+            className="absolute right-3 bottom-3 z-40 rounded-md border bg-background/85 p-1.5 text-muted-foreground shadow-sm backdrop-blur transition-colors hover:bg-muted hover:text-foreground"
+          >
+            {previewVisible ? (
+              <PanelRightCloseIcon className="size-4" />
+            ) : (
+              <PanelRightOpenIcon className="size-4" />
+            )}
+          </button>
+        </div>
       </Panel>
 
-      <PanelResizeHandle className="w-px bg-border transition-colors hover:bg-ring" />
+      {previewVisible && (
+        <>
+          <PanelResizeHandle className="w-px bg-border transition-colors hover:bg-ring" />
 
-      <Panel defaultSize={42.5} minSize={25}>
-        <PdfPreview />
-      </Panel>
+          <Panel defaultSize={42.5} minSize={25}>
+            <PdfPreview />
+          </Panel>
+        </>
+      )}
     </PanelGroup>
   );
 }

--- a/apps/desktop/src/stores/preview-store.ts
+++ b/apps/desktop/src/stores/preview-store.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface PreviewState {
+  visible: boolean;
+  toggle: () => void;
+  setVisible: (v: boolean) => void;
+}
+
+export const usePreviewStore = create<PreviewState>((set) => ({
+  visible: true,
+  toggle: () => set((s) => ({ visible: !s.visible })),
+  setVisible: (v) => set({ visible: v }),
+}));


### PR DESCRIPTION
## Summary
Adds an optional way to hide the right-side PDF preview pane, so the
editor can use the full window when you're focused on writing rather
than reviewing the typeset output.

## Behaviour
- **Cmd+\ / Ctrl+\** toggles the PDF preview
- A small floating button at the bottom-right of the editor panel
  toggles it via mouse (icon swaps between PanelRightClose / PanelRightOpen)
- When hidden, the editor `Panel` expands from `defaultSize=42.5` to
  `defaultSize=85` to fill the freed space
- Default is unchanged: preview is visible on startup

## Implementation
- New `usePreviewStore` (Zustand) with `visible / toggle / setVisible`
- `WorkspaceLayout` reads the store, conditionally renders the
  `PanelResizeHandle` + `PdfPreview` pane, and registers a global
  Cmd+\ keyboard listener
- 58 LOC inserted, 6 LOC modified

## Test plan
- [ ] Open a project; preview is visible by default
- [ ] Press Cmd+\; preview hides, editor expands; press again, restored
- [ ] Click the floating button; same behaviour
- [ ] Drag the preview resize handle while visible; still works