### PR TITLE
feat(editor): visual styling for LaTeX commands in source view

### DIFF
--- a/apps/desktop/src/components/workspace/editor/latex-editor.tsx
+++ b/apps/desktop/src/components/workspace/editor/latex-editor.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState, useMemo } from "react";
 import { Compartment, EditorState, Prec, Transaction } from "@codemirror/state";
+import { latexStyling } from "./latex-styling-extension";
 import {
   EditorView,
   keymap,
@@ -670,6 +671,7 @@ export function LatexEditor() {
         search(),
         highlightSelectionMatches(),
         mergeCompartmentRef.current.of([]),
+        latexStyling(),
         updateListener,
         EditorView.lineWrapping,
         scrollPastEnd(),

--- a/apps/desktop/src/components/workspace/editor/latex-styling-extension.ts
+++ b/apps/desktop/src/components/workspace/editor/latex-styling-extension.ts
@@ -1,0 +1,74 @@
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  ViewPlugin,
+  type ViewUpdate,
+} from "@codemirror/view";
+import { RangeSetBuilder } from "@codemirror/state";
+
+// Single-arg LaTeX commands we visually style in source view.
+// Match the common simple form (no nested braces) — sufficient for
+// "make bold things bold, make section titles bigger".
+const PATTERNS: { re: RegExp; cls: string }[] = [
+  { re: /\\section\*?\{([^{}]*)\}/g, cls: "tex-section" },
+  { re: /\\subsection\*?\{([^{}]*)\}/g, cls: "tex-subsection" },
+  { re: /\\subsubsection\*?\{([^{}]*)\}/g, cls: "tex-subsubsection" },
+  { re: /\\paragraph\*?\{([^{}]*)\}/g, cls: "tex-paragraph" },
+  { re: /\\textbf\{([^{}]*)\}/g, cls: "tex-bold" },
+  { re: /\\textit\{([^{}]*)\}/g, cls: "tex-italic" },
+  { re: /\\emph\{([^{}]*)\}/g, cls: "tex-italic" },
+];
+
+function buildDecorations(view: EditorView): DecorationSet {
+  type R = { from: number; to: number; cls: string };
+  const ranges: R[] = [];
+  for (const { from, to } of view.visibleRanges) {
+    const text = view.state.doc.sliceString(from, to);
+    for (const { re, cls } of PATTERNS) {
+      for (const m of text.matchAll(re)) {
+        const idx = m.index ?? 0;
+        const match = m[0];
+        const argStart = from + idx + match.indexOf("{") + 1;
+        const argEnd = from + idx + match.length - 1;
+        if (argEnd > argStart) ranges.push({ from: argStart, to: argEnd, cls });
+      }
+    }
+  }
+  // RangeSetBuilder requires ranges sorted by `from` (then `to`).
+  ranges.sort((a, b) => a.from - b.from || a.to - b.to);
+  const builder = new RangeSetBuilder<Decoration>();
+  for (const r of ranges) {
+    builder.add(r.from, r.to, Decoration.mark({ class: r.cls }));
+  }
+  return builder.finish();
+}
+
+const theme = EditorView.theme({
+  ".cm-content": {
+    fontFamily: '"Times New Roman", Times, serif',
+  },
+  ".tex-section": { fontSize: "1.6em", fontWeight: "700" },
+  ".tex-subsection": { fontSize: "1.35em", fontWeight: "700" },
+  ".tex-subsubsection": { fontSize: "1.15em", fontWeight: "700" },
+  ".tex-paragraph": { fontWeight: "700" },
+  ".tex-bold": { fontWeight: "700" },
+  ".tex-italic": { fontStyle: "italic" },
+});
+
+const plugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+    constructor(view: EditorView) {
+      this.decorations = buildDecorations(view);
+    }
+    update(u: ViewUpdate) {
+      if (u.docChanged || u.viewportChanged) {
+        this.decorations = buildDecorations(u.view);
+      }
+    }
+  },
+  { decorations: (v) => v.decorations },
+);
+
+export const latexStyling = () => [theme, plugin];


### PR DESCRIPTION
## Summary
Adds a CodeMirror extension that visually styles a handful of common
LaTeX commands in source mode, so the source view feels closer to a
typeset document without leaving plain-text editing.

## Behaviour
- Editor content rendered in Times New Roman
- `\section{...}` / `\subsection{...}` / `\subsubsection{...}` /
  `\paragraph{...}` headings are scaled and bold
- `\textbf{...}` is bold, `\textit{...}` / `\emph{...}` are italic
- Source remains plain LaTeX; only the rendering is styled

## Implementation
- `latex-styling-extension.ts`: a `ViewPlugin` that walks visible ranges,
  matches a small set of single-arg LaTeX patterns, and emits
  `Decoration.mark` ranges via `RangeSetBuilder`. Rebuilt on doc /
  viewport change.
- Wired into the existing editor extensions array in `latex-editor.tsx`
- 76 LOC across one new file and 2 line additions

## Question for maintainers
Would you prefer this be opt-in via a settings toggle (the existing
`useSettingsStore` could host it), or always-on? Happy to wire up a
toggle if preferred — defaults can be either way.

## Test plan
- [ ] Open any `.tex` file with `\section`, `\textbf`, etc.; commands'
      contents render with appropriate styling
- [ ] Selection / cursor / typing inside styled regions still works
- [ ] Large file scroll: decorations rebuild correctly per visible range

## Out of scope (for follow-ups)
- Nested-brace matching
- Math rendering / KaTeX preview
- Multi-arg commands beyond the small core set