### PR TITLE
RFC: per-passage comments & suggestions for collaborative editing

### DIFF
--- a/apps/desktop/src-tauri/src/comments.rs
+++ b/apps/desktop/src-tauri/src/comments.rs
@@ -1,0 +1,332 @@
+// Per-passage comments + suggestions persisted to
+// `<project_root>/.claudeprism/comments.json`.
+//
+// Schema is the canonical contract with the frontend AND with any external
+// Claude Code session that wants to read or append. See `Comment` below.
+//
+// A small polling watcher emits a `comments-changed` event so external writes
+// (e.g. from a Claude Code session) appear live in the UI.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter};
+use uuid::Uuid;
+
+// ---------- Schema ----------
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct CommentAnchor {
+    pub line_start: u32,
+    pub line_end: u32,
+    pub char_start: u32,
+    pub char_end: u32,
+    pub quoted_text: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Reply {
+    pub author: String,
+    pub body: String,
+    pub ts: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Comment {
+    pub id: String,
+    pub file_path: String,
+    pub anchor: CommentAnchor,
+    #[serde(rename = "type")]
+    pub ty: String,
+    pub author: String,
+    pub comment: String,
+    pub proposed_replacement: Option<String>,
+    pub status: String,
+    pub replies: Vec<Reply>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+struct CommentsFile {
+    comments: Vec<Comment>,
+}
+
+// ---------- Paths + IO ----------
+
+fn comments_path(project_root: &str) -> PathBuf {
+    Path::new(project_root).join(".claudeprism").join("comments.json")
+}
+
+fn notifications_path(project_root: &str) -> PathBuf {
+    Path::new(project_root)
+        .join(".claudeprism")
+        .join("notifications.log")
+}
+
+fn read_file_or_default(project_root: &str) -> Result<CommentsFile, String> {
+    let path = comments_path(project_root);
+    if !path.exists() {
+        return Ok(CommentsFile::default());
+    }
+    let raw = fs::read_to_string(&path).map_err(|e| format!("read {:?}: {}", path, e))?;
+    if raw.trim().is_empty() {
+        return Ok(CommentsFile::default());
+    }
+    serde_json::from_str::<CommentsFile>(&raw).map_err(|e| format!("parse comments.json: {}", e))
+}
+
+fn atomic_write(path: &Path, data: &str) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "destination has no parent".to_string())?;
+    fs::create_dir_all(parent).map_err(|e| format!("mkdir {:?}: {}", parent, e))?;
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| "destination has no file name".to_string())?
+        .to_string_lossy();
+    let tmp = parent.join(format!(".{}.tmp", file_name));
+    {
+        let mut f =
+            fs::File::create(&tmp).map_err(|e| format!("create tmp {:?}: {}", tmp, e))?;
+        f.write_all(data.as_bytes())
+            .map_err(|e| format!("write tmp: {}", e))?;
+        f.sync_all().map_err(|e| format!("sync tmp: {}", e))?;
+    }
+    fs::rename(&tmp, path).map_err(|e| format!("rename tmp -> dest: {}", e))?;
+    Ok(())
+}
+
+fn append_notification(project_root: &str, event: &serde_json::Value) -> Result<(), String> {
+    let path = notifications_path(project_root);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("mkdir notif parent: {}", e))?;
+    }
+    let mut f = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .map_err(|e| format!("open notif log: {}", e))?;
+    writeln!(f, "{}", event).map_err(|e| format!("write notif: {}", e))?;
+    Ok(())
+}
+
+fn now_iso() -> String {
+    Utc::now().to_rfc3339()
+}
+
+fn gen_id() -> String {
+    let now = Utc::now().format("%Y-%m-%dT%H-%M-%S").to_string();
+    let suffix: String = Uuid::new_v4().to_string().chars().take(4).collect();
+    format!("cmt_{}_{}", now, suffix)
+}
+
+fn write_all(project_root: &str, file: &CommentsFile) -> Result<(), String> {
+    let serialized =
+        serde_json::to_string_pretty(file).map_err(|e| format!("serialize: {}", e))?;
+    atomic_write(&comments_path(project_root), &serialized)
+}
+
+// ---------- Commands ----------
+
+#[tauri::command]
+pub fn comments_list(project_root: String) -> Result<Vec<Comment>, String> {
+    let file = read_file_or_default(&project_root)?;
+    Ok(file.comments)
+}
+
+#[derive(Deserialize)]
+pub struct AddCommentInput {
+    pub project_root: String,
+    pub file_path: String,
+    pub anchor: CommentAnchor,
+    #[serde(rename = "type")]
+    pub ty: String,
+    pub author: String,
+    pub comment: String,
+    pub proposed_replacement: Option<String>,
+}
+
+#[tauri::command]
+pub fn comments_add(input: AddCommentInput) -> Result<Comment, String> {
+    if input.ty != "comment" && input.ty != "suggestion" {
+        return Err(format!("invalid type: {}", input.ty));
+    }
+    let mut file = read_file_or_default(&input.project_root)?;
+    let now = now_iso();
+    let new_comment = Comment {
+        id: gen_id(),
+        file_path: input.file_path.clone(),
+        anchor: input.anchor,
+        ty: input.ty.clone(),
+        author: input.author.clone(),
+        comment: input.comment,
+        proposed_replacement: input.proposed_replacement,
+        status: "open".to_string(),
+        replies: vec![],
+        created_at: now.clone(),
+        updated_at: now.clone(),
+    };
+    file.comments.push(new_comment.clone());
+    write_all(&input.project_root, &file)?;
+    append_notification(
+        &input.project_root,
+        &serde_json::json!({
+            "ts": now,
+            "actor": input.author,
+            "type": "comment_added",
+            "comment_type": input.ty,
+            "comment_id": new_comment.id,
+            "file_path": input.file_path,
+        }),
+    )?;
+    Ok(new_comment)
+}
+
+#[derive(Deserialize)]
+pub struct UpdateCommentInput {
+    pub project_root: String,
+    pub id: String,
+    pub patch: serde_json::Value,
+}
+
+#[tauri::command]
+pub fn comments_update(input: UpdateCommentInput) -> Result<Comment, String> {
+    let mut file = read_file_or_default(&input.project_root)?;
+    let idx = file
+        .comments
+        .iter()
+        .position(|c| c.id == input.id)
+        .ok_or_else(|| format!("comment not found: {}", input.id))?;
+
+    let now = now_iso();
+    let mut value =
+        serde_json::to_value(&file.comments[idx]).map_err(|e| format!("to value: {}", e))?;
+    if let (Some(target), Some(patch)) = (value.as_object_mut(), input.patch.as_object()) {
+        for (k, v) in patch {
+            // Disallow mutating id / created_at via patch
+            if k == "id" || k == "created_at" {
+                continue;
+            }
+            target.insert(k.clone(), v.clone());
+        }
+        target.insert(
+            "updated_at".to_string(),
+            serde_json::Value::String(now.clone()),
+        );
+    }
+    let updated: Comment =
+        serde_json::from_value(value).map_err(|e| format!("from value: {}", e))?;
+    file.comments[idx] = updated.clone();
+    write_all(&input.project_root, &file)?;
+    append_notification(
+        &input.project_root,
+        &serde_json::json!({
+            "ts": now,
+            "actor": "system",
+            "type": "comment_updated",
+            "comment_id": input.id,
+            "patch": input.patch,
+        }),
+    )?;
+    Ok(updated)
+}
+
+#[derive(Deserialize)]
+pub struct AddReplyInput {
+    pub project_root: String,
+    pub id: String,
+    pub author: String,
+    pub body: String,
+}
+
+#[tauri::command]
+pub fn comments_reply(input: AddReplyInput) -> Result<Comment, String> {
+    let mut file = read_file_or_default(&input.project_root)?;
+    let idx = file
+        .comments
+        .iter()
+        .position(|c| c.id == input.id)
+        .ok_or_else(|| format!("comment not found: {}", input.id))?;
+    let now = now_iso();
+    let reply = Reply {
+        author: input.author.clone(),
+        body: input.body.clone(),
+        ts: now.clone(),
+    };
+    file.comments[idx].replies.push(reply);
+    file.comments[idx].updated_at = now.clone();
+    let updated = file.comments[idx].clone();
+    write_all(&input.project_root, &file)?;
+    append_notification(
+        &input.project_root,
+        &serde_json::json!({
+            "ts": now,
+            "actor": input.author,
+            "type": "reply_added",
+            "comment_id": input.id,
+            "body_preview": input.body.chars().take(80).collect::<String>(),
+        }),
+    )?;
+    Ok(updated)
+}
+
+// ---------- Polling watcher ----------
+
+pub struct CommentsWatcherState(pub Mutex<Option<tauri::async_runtime::JoinHandle<()>>>);
+
+impl Default for CommentsWatcherState {
+    fn default() -> Self {
+        Self(Mutex::new(None))
+    }
+}
+
+#[tauri::command]
+pub fn comments_start_watcher(
+    app: AppHandle,
+    project_root: String,
+    state: tauri::State<'_, CommentsWatcherState>,
+) -> Result<(), String> {
+    // Stop any existing watcher.
+    if let Ok(mut guard) = state.0.lock() {
+        if let Some(handle) = guard.take() {
+            handle.abort();
+        }
+    }
+    let path = comments_path(&project_root);
+    let app_for_task = app.clone();
+    let handle = tauri::async_runtime::spawn(async move {
+        let mut last_mtime: Option<std::time::SystemTime> = None;
+        loop {
+            tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+            let current = fs::metadata(&path).ok().and_then(|m| m.modified().ok());
+            if last_mtime.is_some() && current != last_mtime {
+                let _ = app_for_task.emit(
+                    "comments-changed",
+                    serde_json::json!({
+                        "path": path.to_string_lossy().into_owned(),
+                    }),
+                );
+            }
+            last_mtime = current;
+        }
+    });
+    if let Ok(mut guard) = state.0.lock() {
+        *guard = Some(handle);
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn comments_stop_watcher(state: tauri::State<'_, CommentsWatcherState>) -> Result<(), String> {
+    if let Ok(mut guard) = state.0.lock() {
+        if let Some(handle) = guard.take() {
+            handle.abort();
+        }
+    }
+    Ok(())
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod claude;
+mod comments;
 mod history;
 mod latex;
 mod skills;
@@ -342,6 +343,7 @@ pub fn run() {
         .manage(claude::ClaudeProcessState::default())
         .manage(latex::LatexCompilerState::default())
         .manage(zotero::ZoteroOAuthState::default())
+        .manage(comments::CommentsWatcherState::default())
         .setup(|app| {
             // Safety net: force-show the main window after a timeout if the
             // frontend JS never calls `getCurrentWindow().show()`.
@@ -412,6 +414,12 @@ pub fn run() {
             uv::setup_project_venv,
             uv::uv_add_packages,
             uv::uv_run_command,
+            comments::comments_list,
+            comments::comments_add,
+            comments::comments_update,
+            comments::comments_reply,
+            comments::comments_start_watcher,
+            comments::comments_stop_watcher,
             get_system_info,
             open_debug_window,
         ])

--- a/apps/desktop/src/components/workspace/comments-panel.tsx
+++ b/apps/desktop/src/components/workspace/comments-panel.tsx
@@ -1,0 +1,854 @@
+// Sidebar panel listing per-passage comments + suggestions.
+//
+// Handles cross-component custom events dispatched by the CodeMirror
+// hover popover and click handler:
+//   - comments:focus-in-panel  → scroll to comment, briefly highlight
+//   - comments:edit-request    → enter inline edit mode for the comment
+//   - comments:reply-request   → focus the reply textarea for the comment
+//   - comments:resolve-request → status = "resolved"
+//   - comments:reject-request  → status = "rejected"
+//   - comments:reopen-request  → status = "open"
+//   - comments:apply-request   → apply the proposed replacement (re-dispatches
+//                                comments:apply-suggestion for the editor)
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  MessageSquareIcon,
+  LightbulbIcon,
+  CheckIcon,
+  TrashIcon,
+  RefreshCwIcon,
+  CornerDownRightIcon,
+  ChevronRightIcon,
+  PencilIcon,
+  XIcon,
+  SearchIcon,
+  ArrowUpDownIcon,
+} from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
+import { useDocumentStore } from "@/stores/document-store";
+import { useCommentsStore } from "@/stores/comments-store";
+import type { Comment, CommentStatus, Reply } from "@/lib/tauri/comments";
+
+export function CommentsHeader() {
+  const openCount = useCommentsStore(
+    (s) => s.comments.filter((c) => c.status === "open").length,
+  );
+  const refresh = useCommentsStore((s) => s.refresh);
+  return (
+    <div className="flex w-full items-center justify-between px-3 text-muted-foreground text-xs">
+      <div className="flex items-center gap-1.5 uppercase tracking-wider">
+        <MessageSquareIcon className="size-3" />
+        <span>Comments</span>
+        {openCount > 0 && (
+          <span className="rounded bg-amber-500/20 px-1.5 py-0.5 font-mono text-[10px] text-amber-700 dark:text-amber-300">
+            {openCount}
+          </span>
+        )}
+      </div>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="size-5"
+        onClick={() => {
+          refresh().catch(() => {});
+        }}
+        title="Refresh"
+        aria-label="Refresh comments"
+      >
+        <RefreshCwIcon className="size-3" />
+      </Button>
+    </div>
+  );
+}
+
+const STATUS_FILTERS: { id: CommentStatus | "all"; label: string }[] = [
+  { id: "open", label: "Open" },
+  { id: "resolved", label: "Resolved" },
+  { id: "all", label: "All" },
+];
+
+type SortKey = "position" | "recent" | "oldest";
+
+export function CommentsPanel() {
+  const comments = useCommentsStore((s) => s.comments);
+  const [statusFilter, setStatusFilter] = useState<CommentStatus | "all">(
+    "open",
+  );
+  const [currentFileOnly, setCurrentFileOnly] = useState(false);
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<SortKey>("position");
+
+  const activeFilePath = useDocumentStore(
+    (s) => s.files.find((f) => f.id === s.activeFileId)?.relativePath ?? null,
+  );
+
+  const filtered = useMemo(() => {
+    let out = comments;
+    if (statusFilter !== "all")
+      out = out.filter((c) => c.status === statusFilter);
+    if (currentFileOnly && activeFilePath)
+      out = out.filter((c) => c.file_path === activeFilePath);
+    const q = search.trim().toLowerCase();
+    if (q) {
+      out = out.filter((c) => {
+        if (c.comment.toLowerCase().includes(q)) return true;
+        if (c.anchor.quoted_text.toLowerCase().includes(q)) return true;
+        if (c.author.toLowerCase().includes(q)) return true;
+        if (c.proposed_replacement?.toLowerCase().includes(q)) return true;
+        if (c.replies.some((r) => r.body.toLowerCase().includes(q)))
+          return true;
+        return false;
+      });
+    }
+    const sorted = [...out];
+    if (sort === "position") {
+      sorted.sort((a, b) => {
+        if (a.file_path !== b.file_path)
+          return a.file_path.localeCompare(b.file_path);
+        return a.anchor.char_start - b.anchor.char_start;
+      });
+    } else if (sort === "recent") {
+      sorted.sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+    } else {
+      sorted.sort((a, b) => a.updated_at.localeCompare(b.updated_at));
+    }
+    return sorted;
+  }, [comments, statusFilter, currentFileOnly, activeFilePath, search, sort]);
+
+  // Cross-component event: focus + scroll to a comment in the panel.
+  const [focusedId, setFocusedId] = useState<string | null>(null);
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ id: string }>).detail;
+      if (!detail?.id) return;
+      setFocusedId(detail.id);
+      const t = setTimeout(() => setFocusedId(null), 1800);
+      return () => clearTimeout(t);
+    };
+    window.addEventListener(
+      "comments:focus-in-panel",
+      handler as EventListener,
+    );
+    return () =>
+      window.removeEventListener(
+        "comments:focus-in-panel",
+        handler as EventListener,
+      );
+  }, []);
+
+  // Cross-component event: cursor sits inside a comment anchor → mark active.
+  const [activeId, setActiveId] = useState<string | null>(null);
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ id: string | null }>).detail;
+      setActiveId(detail?.id ?? null);
+    };
+    window.addEventListener("comments:active-set", handler as EventListener);
+    return () =>
+      window.removeEventListener(
+        "comments:active-set",
+        handler as EventListener,
+      );
+  }, []);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex shrink-0 flex-wrap items-center gap-1 border-sidebar-border border-b px-2 py-1">
+        {STATUS_FILTERS.map((f) => (
+          <button
+            key={f.id}
+            onClick={() => setStatusFilter(f.id)}
+            className={cn(
+              "rounded px-1.5 py-0.5 font-medium text-[10px] uppercase tracking-wide",
+              statusFilter === f.id
+                ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                : "text-muted-foreground hover:bg-sidebar-accent/50",
+            )}
+          >
+            {f.label}
+          </button>
+        ))}
+        <button
+          onClick={() => setCurrentFileOnly((v) => !v)}
+          title="Toggle filter: only comments on the current file"
+          className={cn(
+            "ml-auto rounded px-1.5 py-0.5 font-medium text-[10px] uppercase tracking-wide",
+            currentFileOnly
+              ? "bg-sidebar-accent text-sidebar-accent-foreground"
+              : "text-muted-foreground hover:bg-sidebar-accent/50",
+          )}
+        >
+          this file
+        </button>
+      </div>
+      <div className="flex shrink-0 items-center gap-1 border-sidebar-border border-b px-2 py-1">
+        <div className="relative flex-1">
+          <SearchIcon className="absolute top-1.5 left-1.5 size-3 text-muted-foreground" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search comments..."
+            className="h-6 pl-6 text-[11px]"
+          />
+          {search && (
+            <button
+              onClick={() => setSearch("")}
+              className="absolute top-1.5 right-1.5 text-muted-foreground hover:text-foreground"
+              title="Clear"
+              aria-label="Clear search"
+            >
+              <XIcon className="size-3" />
+            </button>
+          )}
+        </div>
+        <button
+          onClick={() =>
+            setSort((s) =>
+              s === "position"
+                ? "recent"
+                : s === "recent"
+                  ? "oldest"
+                  : "position",
+            )
+          }
+          className="flex items-center gap-1 rounded px-1.5 py-1 text-[10px] text-muted-foreground uppercase tracking-wide hover:bg-sidebar-accent/50"
+          title={`Sort: ${sort} (click to cycle)`}
+        >
+          <ArrowUpDownIcon className="size-2.5" />
+          {sort === "position" ? "pos" : sort === "recent" ? "new" : "old"}
+        </button>
+      </div>
+      <ScrollArea className="min-h-0 flex-1">
+        {filtered.length === 0 ? (
+          <div className="px-3 py-6 text-center text-muted-foreground text-xs">
+            No {statusFilter === "all" ? "" : statusFilter} comments
+            {currentFileOnly ? " on this file" : ""}.
+            <br />
+            <span className="text-[10px]">
+              Highlight text in the editor, click Comment or Suggest.
+            </span>
+          </div>
+        ) : (
+          <ul className="space-y-1.5 p-1.5">
+            {filtered.map((c) => (
+              <li key={c.id}>
+                <CommentRow
+                  comment={c}
+                  isFocused={focusedId === c.id}
+                  isActive={activeId === c.id}
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+      </ScrollArea>
+    </div>
+  );
+}
+
+interface CommentRowProps {
+  comment: Comment;
+  isFocused: boolean;
+  isActive: boolean;
+}
+
+function CommentRow({ comment, isFocused, isActive }: CommentRowProps) {
+  const updateComment = useCommentsStore((s) => s.updateComment);
+  const reply = useCommentsStore((s) => s.reply);
+  const setActiveFile = useDocumentStore((s) => s.setActiveFile);
+  const files = useDocumentStore((s) => s.files);
+  const activeFilePath = useDocumentStore(
+    (s) => s.files.find((f) => f.id === s.activeFileId)?.relativePath ?? null,
+  );
+
+  const [expanded, setExpanded] = useState(true);
+  const [replyText, setReplyText] = useState("");
+  const [editingComment, setEditingComment] = useState(false);
+  const [commentDraft, setCommentDraft] = useState(comment.comment);
+  const [suggestionDraft, setSuggestionDraft] = useState(
+    comment.proposed_replacement ?? "",
+  );
+  const [editingReplyIdx, setEditingReplyIdx] = useState<number | null>(null);
+  const [replyDraft, setReplyDraft] = useState("");
+
+  const rowRef = useRef<HTMLDivElement>(null);
+  const replyAreaRef = useRef<HTMLTextAreaElement>(null);
+
+  const isSuggestion = comment.type === "suggestion";
+  const isOpen = comment.status === "open";
+
+  // Reset draft when the underlying comment changes (e.g. external edit)
+  useEffect(() => {
+    if (!editingComment) {
+      setCommentDraft(comment.comment);
+      setSuggestionDraft(comment.proposed_replacement ?? "");
+    }
+  }, [comment.comment, comment.proposed_replacement, editingComment]);
+
+  // Scroll into view + pulse when focused
+  useEffect(() => {
+    if (isFocused && rowRef.current) {
+      rowRef.current.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }, [isFocused]);
+
+  const isClaude = comment.author === "claude";
+  const palette = (() => {
+    if (comment.status === "resolved" || comment.status === "applied")
+      return "border-l-emerald-500/60";
+    if (comment.status === "rejected") return "border-l-zinc-500/40";
+    if (comment.status === "orphaned") return "border-l-pink-500/60";
+    if (isSuggestion)
+      return isClaude ? "border-l-indigo-500/70" : "border-l-sky-500/70";
+    return isClaude ? "border-l-violet-500/70" : "border-l-amber-500/70";
+  })();
+
+  const switchToCommentFile = (): boolean => {
+    if (comment.file_path === activeFilePath) return true;
+    const target = files.find((f) => f.relativePath === comment.file_path);
+    if (!target) return false;
+    setActiveFile(target.id);
+    return true;
+  };
+
+  const focusInEditor = () => {
+    if (!switchToCommentFile()) return;
+    setTimeout(() => {
+      window.dispatchEvent(
+        new CustomEvent("comments:jump", {
+          detail: {
+            from: comment.anchor.char_start,
+            to: comment.anchor.char_end,
+          },
+        }),
+      );
+    }, 60);
+  };
+
+  const applySuggestion = () => {
+    if (!isSuggestion || !comment.proposed_replacement) return;
+    if (!switchToCommentFile()) return;
+    setTimeout(() => {
+      window.dispatchEvent(
+        new CustomEvent("comments:apply-suggestion", {
+          detail: {
+            from: comment.anchor.char_start,
+            to: comment.anchor.char_end,
+            replacement: comment.proposed_replacement,
+          },
+        }),
+      );
+      updateComment(comment.id, { status: "applied" }).catch(() => {});
+    }, 60);
+  };
+
+  const startEdit = () => {
+    setEditingComment(true);
+    setExpanded(true);
+  };
+
+  const saveEdit = async () => {
+    const patch: Parameters<typeof updateComment>[1] = {
+      comment: commentDraft.trim(),
+    };
+    if (isSuggestion) {
+      patch.proposed_replacement = suggestionDraft;
+    }
+    try {
+      await updateComment(comment.id, patch);
+    } finally {
+      setEditingComment(false);
+    }
+  };
+
+  const cancelEdit = () => {
+    setCommentDraft(comment.comment);
+    setSuggestionDraft(comment.proposed_replacement ?? "");
+    setEditingComment(false);
+  };
+
+  const handleReplySubmit = () => {
+    const body = replyText.trim();
+    if (!body) return;
+    reply(comment.id, body).catch(() => {});
+    setReplyText("");
+  };
+
+  const handleReplyAndResolve = async () => {
+    const body = replyText.trim();
+    if (!body) return;
+    try {
+      await reply(comment.id, body);
+      await updateComment(comment.id, { status: "resolved" });
+    } finally {
+      setReplyText("");
+    }
+  };
+
+  const startReplyEdit = (idx: number, r: Reply) => {
+    setEditingReplyIdx(idx);
+    setReplyDraft(r.body);
+  };
+
+  const saveReplyEdit = async () => {
+    if (editingReplyIdx === null) return;
+    const idx = editingReplyIdx;
+    const trimmed = replyDraft.trim();
+    if (!trimmed) {
+      setEditingReplyIdx(null);
+      return;
+    }
+    const nextReplies = comment.replies.map((r, i) =>
+      i === idx ? { ...r, body: trimmed } : r,
+    );
+    try {
+      await updateComment(comment.id, {
+        replies: nextReplies,
+      } as Parameters<typeof updateComment>[1]);
+    } finally {
+      setEditingReplyIdx(null);
+    }
+  };
+
+  // === Listen for cross-component action requests targeting this comment ===
+  useEffect(() => {
+    const matchesMe = (e: Event) => {
+      const id = (e as CustomEvent<{ id: string }>).detail?.id;
+      return id === comment.id;
+    };
+
+    const onEdit = (e: Event) => {
+      if (!matchesMe(e)) return;
+      startEdit();
+    };
+    const onReplyReq = (e: Event) => {
+      if (!matchesMe(e)) return;
+      setExpanded(true);
+      setTimeout(() => replyAreaRef.current?.focus(), 50);
+    };
+    const onResolve = (e: Event) => {
+      if (!matchesMe(e)) return;
+      updateComment(comment.id, { status: "resolved" }).catch(() => {});
+    };
+    const onReject = (e: Event) => {
+      if (!matchesMe(e)) return;
+      updateComment(comment.id, { status: "rejected" }).catch(() => {});
+    };
+    const onReopen = (e: Event) => {
+      if (!matchesMe(e)) return;
+      updateComment(comment.id, { status: "open" }).catch(() => {});
+    };
+    const onApply = (e: Event) => {
+      if (!matchesMe(e)) return;
+      applySuggestion();
+    };
+
+    window.addEventListener("comments:edit-request", onEdit as EventListener);
+    window.addEventListener(
+      "comments:reply-request",
+      onReplyReq as EventListener,
+    );
+    window.addEventListener(
+      "comments:resolve-request",
+      onResolve as EventListener,
+    );
+    window.addEventListener(
+      "comments:reject-request",
+      onReject as EventListener,
+    );
+    window.addEventListener(
+      "comments:reopen-request",
+      onReopen as EventListener,
+    );
+    window.addEventListener("comments:apply-request", onApply as EventListener);
+    return () => {
+      window.removeEventListener(
+        "comments:edit-request",
+        onEdit as EventListener,
+      );
+      window.removeEventListener(
+        "comments:reply-request",
+        onReplyReq as EventListener,
+      );
+      window.removeEventListener(
+        "comments:resolve-request",
+        onResolve as EventListener,
+      );
+      window.removeEventListener(
+        "comments:reject-request",
+        onReject as EventListener,
+      );
+      window.removeEventListener(
+        "comments:reopen-request",
+        onReopen as EventListener,
+      );
+      window.removeEventListener(
+        "comments:apply-request",
+        onApply as EventListener,
+      );
+    };
+    // applySuggestion captures isSuggestion + replacement from `comment` closure
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [comment.id, comment.proposed_replacement, comment.replies]);
+
+  return (
+    <div
+      ref={rowRef}
+      className={cn(
+        "rounded border-l-2 bg-sidebar-accent/30 px-2 py-1.5 text-xs transition-all",
+        palette,
+        isActive && !isFocused && "bg-sidebar-accent/70",
+        isFocused &&
+          "bg-amber-50/30 ring-2 ring-amber-400/70 dark:bg-amber-900/15",
+      )}
+    >
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className="flex w-full items-center gap-1 text-left"
+        title={expanded ? "Collapse" : "Expand"}
+      >
+        <ChevronRightIcon
+          className={cn(
+            "size-3 shrink-0 transition-transform",
+            expanded && "rotate-90",
+          )}
+        />
+        {isSuggestion ? (
+          <LightbulbIcon
+            className={cn(
+              "size-3 shrink-0",
+              isClaude ? "text-indigo-500" : "text-sky-500",
+            )}
+          />
+        ) : (
+          <MessageSquareIcon
+            className={cn(
+              "size-3 shrink-0",
+              isClaude ? "text-violet-500" : "text-amber-500",
+            )}
+          />
+        )}
+        <AuthorChip author={comment.author} />
+        <span className="truncate font-medium">{comment.author}</span>
+        <span className="shrink-0 text-[10px] text-muted-foreground">
+          {timeAgo(comment.updated_at)}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="mt-1 space-y-1.5">
+          <button
+            onClick={focusInEditor}
+            className="block w-full truncate text-left text-[10px] text-muted-foreground italic hover:underline"
+            title="Jump to passage"
+          >
+            "{comment.anchor.quoted_text.slice(0, 80)}
+            {comment.anchor.quoted_text.length > 80 ? "..." : ""}"
+          </button>
+
+          {editingComment ? (
+            <div className="space-y-1">
+              <Textarea
+                value={commentDraft}
+                onChange={(e) => setCommentDraft(e.target.value)}
+                className="min-h-[60px] text-[11px]"
+                autoFocus
+                onKeyDown={(e) => {
+                  if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                    e.preventDefault();
+                    saveEdit();
+                  }
+                  if (e.key === "Escape") {
+                    e.preventDefault();
+                    cancelEdit();
+                  }
+                }}
+              />
+              {isSuggestion && (
+                <Textarea
+                  value={suggestionDraft}
+                  onChange={(e) => setSuggestionDraft(e.target.value)}
+                  className="min-h-[60px] font-mono text-[10px]"
+                  placeholder="Proposed replacement"
+                />
+              )}
+              <div className="flex items-center gap-1">
+                <Button
+                  size="sm"
+                  variant="default"
+                  className="h-6 px-2 text-[10px]"
+                  onClick={saveEdit}
+                  disabled={!commentDraft.trim()}
+                >
+                  Save
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-6 px-2 text-[10px]"
+                  onClick={cancelEdit}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <>
+              {comment.comment && (
+                <div className="whitespace-pre-wrap break-words">
+                  {comment.comment}
+                </div>
+              )}
+
+              {isSuggestion && comment.proposed_replacement && (
+                <div className="rounded border border-sky-500/30 bg-sky-500/5 p-1.5">
+                  <div className="mb-0.5 text-[10px] text-sky-700 dark:text-sky-300">
+                    proposed
+                  </div>
+                  <div className="whitespace-pre-wrap break-words font-mono text-[11px] leading-snug">
+                    {comment.proposed_replacement}
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+
+          {comment.replies.length > 0 && (
+            <ul className="space-y-1 border-sidebar-border border-l pl-2">
+              {comment.replies.map((r, i) => (
+                <li key={i} className="group">
+                  <div className="flex items-center gap-1 text-[10px] text-muted-foreground">
+                    <CornerDownRightIcon className="size-2.5" />
+                    <AuthorChip author={r.author} small />
+                    <span className="font-medium">{r.author}</span>
+                    <span>·</span>
+                    <span>{timeAgo(r.ts)}</span>
+                    {editingReplyIdx !== i && (
+                      <button
+                        onClick={() => startReplyEdit(i, r)}
+                        className="ml-auto opacity-0 transition-opacity group-hover:opacity-100"
+                        title="Edit reply"
+                      >
+                        <PencilIcon className="size-2.5" />
+                      </button>
+                    )}
+                  </div>
+                  {editingReplyIdx === i ? (
+                    <div className="space-y-1 pl-3">
+                      <Textarea
+                        value={replyDraft}
+                        onChange={(e) => setReplyDraft(e.target.value)}
+                        className="min-h-[40px] text-[11px]"
+                        autoFocus
+                        onKeyDown={(e) => {
+                          if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                            e.preventDefault();
+                            saveReplyEdit();
+                          }
+                          if (e.key === "Escape") {
+                            e.preventDefault();
+                            setEditingReplyIdx(null);
+                          }
+                        }}
+                      />
+                      <div className="flex items-center gap-1">
+                        <Button
+                          size="sm"
+                          variant="default"
+                          className="h-5 px-1.5 text-[10px]"
+                          onClick={saveReplyEdit}
+                          disabled={!replyDraft.trim()}
+                        >
+                          Save
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="h-5 px-1.5 text-[10px]"
+                          onClick={() => setEditingReplyIdx(null)}
+                        >
+                          Cancel
+                        </Button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="whitespace-pre-wrap break-words pl-3">
+                      {r.body}
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {isOpen && !editingComment && (
+            <div className="flex flex-wrap items-center gap-1 pt-0.5">
+              {isSuggestion && comment.proposed_replacement && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-6 px-1.5 text-[10px]"
+                  onClick={applySuggestion}
+                  title="Apply the proposed replacement"
+                >
+                  <CheckIcon className="mr-1 size-3" />
+                  Apply
+                </Button>
+              )}
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-6 px-1.5 text-[10px]"
+                onClick={startEdit}
+                title="Edit comment text"
+              >
+                <PencilIcon className="mr-1 size-3" />
+                Edit
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-6 px-1.5 text-[10px]"
+                onClick={() =>
+                  updateComment(comment.id, { status: "resolved" }).catch(
+                    () => {},
+                  )
+                }
+                title="Mark as resolved"
+              >
+                Resolve
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-6 px-1.5 text-[10px]"
+                onClick={() =>
+                  updateComment(comment.id, { status: "rejected" }).catch(
+                    () => {},
+                  )
+                }
+                title="Reject and hide"
+              >
+                <TrashIcon className="size-3" />
+              </Button>
+            </div>
+          )}
+          {!isOpen && !editingComment && (
+            <div className="flex items-center gap-1 pt-0.5">
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-6 px-1.5 text-[10px]"
+                onClick={() =>
+                  updateComment(comment.id, { status: "open" }).catch(() => {})
+                }
+              >
+                Reopen
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-6 px-1.5 text-[10px]"
+                onClick={startEdit}
+              >
+                <PencilIcon className="mr-1 size-3" />
+                Edit
+              </Button>
+            </div>
+          )}
+
+          {isOpen && !editingComment && (
+            <div className="space-y-1 pt-1">
+              <Textarea
+                ref={replyAreaRef}
+                value={replyText}
+                onChange={(e) => setReplyText(e.target.value)}
+                placeholder="Reply..."
+                className="min-h-[28px] resize-none px-1.5 py-1 text-[11px]"
+                onKeyDown={(e) => {
+                  if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                    e.preventDefault();
+                    if (e.shiftKey) {
+                      handleReplyAndResolve();
+                    } else {
+                      handleReplySubmit();
+                    }
+                  }
+                }}
+              />
+              {replyText.trim() && (
+                <div className="flex items-center gap-1">
+                  <Button
+                    size="sm"
+                    variant="default"
+                    className="h-6 px-2 text-[10px]"
+                    onClick={handleReplySubmit}
+                    title="Reply (Cmd+Enter)"
+                  >
+                    Reply
+                    <span className="ml-1 opacity-60">⌘↵</span>
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-6 px-2 text-[10px]"
+                    onClick={handleReplyAndResolve}
+                    title="Reply and mark resolved (Cmd+Shift+Enter)"
+                  >
+                    Reply &amp; Resolve
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AuthorChip({
+  author,
+  small = false,
+}: {
+  author: string;
+  small?: boolean;
+}) {
+  const isClaude = author === "claude";
+  const initial = isClaude ? "C" : (author.charAt(0) || "?").toUpperCase();
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center rounded-full font-bold text-white",
+        small ? "size-3 text-[7px]" : "size-3.5 text-[8px]",
+        isClaude ? "bg-violet-600" : "bg-amber-600",
+      )}
+      title={author}
+    >
+      {initial}
+    </span>
+  );
+}
+
+function timeAgo(iso: string): string {
+  try {
+    const then = Date.parse(iso);
+    if (Number.isNaN(then)) return "";
+    const delta = Date.now() - then;
+    const s = Math.floor(delta / 1000);
+    if (s < 60) return `${s}s`;
+    const m = Math.floor(s / 60);
+    if (m < 60) return `${m}m`;
+    const h = Math.floor(m / 60);
+    if (h < 24) return `${h}h`;
+    const d = Math.floor(h / 24);
+    return `${d}d`;
+  } catch {
+    return "";
+  }
+}

--- a/apps/desktop/src/components/workspace/editor/comment-composer.tsx
+++ b/apps/desktop/src/components/workspace/editor/comment-composer.tsx
@@ -1,0 +1,149 @@
+// Modal composer for adding a new comment or suggestion.
+// Opened from the SelectionToolbar after the user picks "Comment" or "Suggest".
+
+import { useEffect, useRef, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+export interface CommentComposerProps {
+  open: boolean;
+  mode: "comment" | "suggestion";
+  quotedText: string;
+  initialReplacement?: string; // pre-fill for suggestion (typically the original)
+  onCancel: () => void;
+  onSubmit: (data: { comment: string; replacement: string | null }) => void;
+}
+
+export function CommentComposer({
+  open,
+  mode,
+  quotedText,
+  initialReplacement,
+  onCancel,
+  onSubmit,
+}: CommentComposerProps) {
+  const [comment, setComment] = useState("");
+  const [replacement, setReplacement] = useState(initialReplacement ?? "");
+  const commentRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setComment("");
+      setReplacement(initialReplacement ?? quotedText);
+      // Focus the textarea after the dialog has animated in
+      const t = setTimeout(() => commentRef.current?.focus(), 80);
+      return () => clearTimeout(t);
+    }
+  }, [open, initialReplacement, quotedText]);
+
+  const trimmedComment = comment.trim();
+  const canSubmit =
+    mode === "comment"
+      ? trimmedComment.length > 0
+      : trimmedComment.length > 0 || replacement.trim().length > 0;
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    onSubmit({
+      comment: trimmedComment,
+      replacement: mode === "suggestion" ? replacement : null,
+    });
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    // Cmd/Ctrl + Enter = submit
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onCancel()}>
+      <DialogContent className="sm:max-w-lg" onKeyDown={handleKeyDown}>
+        <DialogHeader>
+          <DialogTitle>
+            {mode === "comment" ? "Add comment" : "Suggest change"}
+          </DialogTitle>
+          <DialogDescription>
+            Anchored to the selected passage. Visible to Claude Code via{" "}
+            <code className="rounded bg-muted px-1 text-xs">
+              .claudeprism/comments.json
+            </code>
+            .
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div>
+            <div className="mb-1 text-muted-foreground text-xs">
+              Selected text
+            </div>
+            <div className="max-h-32 overflow-y-auto rounded border border-border bg-muted/40 p-2 font-mono text-xs leading-snug">
+              {quotedText.length > 280
+                ? `${quotedText.slice(0, 280)}…`
+                : quotedText}
+            </div>
+          </div>
+
+          <div>
+            <label
+              htmlFor="comment-composer-text"
+              className="mb-1 block text-xs"
+            >
+              {mode === "comment" ? "Comment" : "Why change this"}
+            </label>
+            <Textarea
+              id="comment-composer-text"
+              ref={commentRef}
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+              placeholder={
+                mode === "comment"
+                  ? "Type a question or note for Claude Code…"
+                  : "Reason for the suggestion (optional if you provide a replacement)…"
+              }
+              className="min-h-[80px]"
+            />
+          </div>
+
+          {mode === "suggestion" && (
+            <div>
+              <label
+                htmlFor="comment-composer-repl"
+                className="mb-1 block text-xs"
+              >
+                Proposed replacement
+              </label>
+              <Textarea
+                id="comment-composer-repl"
+                value={replacement}
+                onChange={(e) => setReplacement(e.target.value)}
+                placeholder="The text that should replace the selection…"
+                className="min-h-[100px] font-mono text-xs"
+              />
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={!canSubmit}>
+            {mode === "comment" ? "Add comment" : "Add suggestion"}
+            <span className="ml-2 text-xs opacity-60">⌘↵</span>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/components/workspace/editor/comments-extension.ts
+++ b/apps/desktop/src/components/workspace/editor/comments-extension.ts
@@ -1,0 +1,613 @@
+// CodeMirror extension for the comments feature:
+//   * highlights commented ranges with a coloured underline (Decoration.mark)
+//   * hover popover showing the comment + replies + action buttons
+//   * click handler that focuses the matching row in the sidebar panel
+//
+// Action buttons inside the hover popover do not mutate state directly;
+// they dispatch CustomEvents to `window` so the React layer (which holds
+// the store and the modal stack) is the single source of truth.
+
+import { StateEffect, StateField, RangeSetBuilder } from "@codemirror/state";
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  hoverTooltip,
+  type Tooltip,
+  gutter,
+  GutterMarker,
+} from "@codemirror/view";
+import type { Comment } from "@/lib/tauri/comments";
+
+export const setCommentsEffect = StateEffect.define<Comment[]>();
+
+interface CommentsState {
+  comments: Comment[];
+  deco: DecorationSet;
+}
+
+function authorClass(c: Comment): string {
+  return c.author === "claude" ? "cmp-author-claude" : "cmp-author-user";
+}
+
+function classForComment(c: Comment): string {
+  const ac = authorClass(c);
+  if (c.status === "resolved" || c.status === "applied")
+    return `cmp-comment cmp-comment-resolved ${ac}`;
+  if (c.status === "rejected") return `cmp-comment cmp-comment-rejected ${ac}`;
+  if (c.status === "orphaned") return `cmp-comment cmp-comment-orphan ${ac}`;
+  if (c.type === "suggestion")
+    return `cmp-comment cmp-comment-suggestion ${ac}`;
+  return `cmp-comment cmp-comment-open ${ac}`;
+}
+
+function buildDecorations(
+  comments: Comment[],
+  docLength: number,
+): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>();
+  const sorted = [...comments].sort(
+    (a, b) => a.anchor.char_start - b.anchor.char_start,
+  );
+  for (const c of sorted) {
+    if (c.status === "rejected") continue;
+    const from = Math.max(0, Math.min(c.anchor.char_start, docLength));
+    const to = Math.max(from, Math.min(c.anchor.char_end, docLength));
+    if (from === to) continue;
+    builder.add(
+      from,
+      to,
+      Decoration.mark({
+        class: classForComment(c),
+        attributes: { "data-comment-id": c.id },
+      }),
+    );
+  }
+  return builder.finish();
+}
+
+export const commentsStateField = StateField.define<CommentsState>({
+  create() {
+    return { comments: [], deco: Decoration.none };
+  },
+  update(state, tr) {
+    let next: CommentsState = {
+      comments: state.comments,
+      deco: state.deco.map(tr.changes),
+    };
+    for (const effect of tr.effects) {
+      if (effect.is(setCommentsEffect)) {
+        next = {
+          comments: effect.value,
+          deco: buildDecorations(effect.value, tr.state.doc.length),
+        };
+      }
+    }
+    return next;
+  },
+  provide: (f) => EditorView.decorations.from(f, (s) => s.deco),
+});
+
+// ---------- Hover tooltip ----------
+
+function commentsAt(state: CommentsState, pos: number): Comment[] {
+  return state.comments.filter(
+    (c) =>
+      c.status !== "rejected" &&
+      c.anchor.char_start <= pos &&
+      pos <= c.anchor.char_end,
+  );
+}
+
+function formatRelTime(iso: string): string {
+  try {
+    const then = Date.parse(iso);
+    if (Number.isNaN(then)) return "";
+    const delta = Math.max(0, Date.now() - then);
+    const s = Math.floor(delta / 1000);
+    if (s < 60) return `${s}s`;
+    const m = Math.floor(s / 60);
+    if (m < 60) return `${m}m`;
+    const h = Math.floor(m / 60);
+    if (h < 24) return `${h}h`;
+    return `${Math.floor(h / 24)}d`;
+  } catch {
+    return "";
+  }
+}
+
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  className?: string,
+  text?: string,
+): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text != null) node.textContent = text;
+  return node;
+}
+
+function dispatch(name: string, detail: unknown) {
+  window.dispatchEvent(new CustomEvent(name, { detail }));
+}
+
+function renderTooltipBody(comments: Comment[]): HTMLElement {
+  const root = el("div", "cmp-tooltip");
+  for (const c of comments) {
+    const card = el("div", "cmp-tooltip-card");
+    if (c.type === "suggestion") card.classList.add("cmp-tooltip-card-sug");
+    if (c.author === "claude") card.classList.add("cmp-tooltip-card-claude");
+
+    // Header: author chip + type + relative time
+    const header = el("div", "cmp-tooltip-header");
+    const chip = el(
+      "span",
+      `cmp-tooltip-chip cmp-tooltip-chip-${c.author === "claude" ? "claude" : "user"}`,
+      c.author === "claude" ? "C" : c.author.charAt(0).toUpperCase() || "?",
+    );
+    chip.title = c.author;
+    header.appendChild(chip);
+    header.appendChild(el("span", "cmp-tooltip-author", c.author));
+    header.appendChild(
+      el(
+        "span",
+        "cmp-tooltip-type",
+        c.type === "suggestion" ? "Suggest" : "Comment",
+      ),
+    );
+    header.appendChild(
+      el("span", "cmp-tooltip-time", formatRelTime(c.updated_at)),
+    );
+    if (c.status !== "open") {
+      header.appendChild(
+        el(
+          "span",
+          `cmp-tooltip-status cmp-tooltip-status-${c.status}`,
+          c.status,
+        ),
+      );
+    }
+    card.appendChild(header);
+
+    // Body
+    if (c.comment) {
+      card.appendChild(el("div", "cmp-tooltip-body", c.comment));
+    }
+
+    // Proposed replacement (for suggestions)
+    if (c.type === "suggestion" && c.proposed_replacement) {
+      const sugWrap = el("div", "cmp-tooltip-sug");
+      sugWrap.appendChild(el("div", "cmp-tooltip-sug-label", "proposed"));
+      sugWrap.appendChild(
+        el("pre", "cmp-tooltip-sug-body", c.proposed_replacement),
+      );
+      card.appendChild(sugWrap);
+    }
+
+    // Replies (compact)
+    if (c.replies.length) {
+      const replies = el("div", "cmp-tooltip-replies");
+      for (const r of c.replies) {
+        const item = el("div", "cmp-tooltip-reply");
+        const head = el("div", "cmp-tooltip-reply-head");
+        head.appendChild(el("span", "cmp-tooltip-reply-author", r.author));
+        head.appendChild(el("span", "cmp-tooltip-time", formatRelTime(r.ts)));
+        item.appendChild(head);
+        item.appendChild(el("div", "cmp-tooltip-reply-body", r.body));
+        replies.appendChild(item);
+      }
+      card.appendChild(replies);
+    }
+
+    // Actions
+    const actions = el("div", "cmp-tooltip-actions");
+    const mkBtn = (label: string, name: string, evt: string) => {
+      const b = el("button", `cmp-tooltip-btn cmp-tooltip-btn-${name}`, label);
+      b.type = "button";
+      b.addEventListener("mousedown", (e) => {
+        // mousedown so the tooltip doesn't hide before click fires
+        e.preventDefault();
+        e.stopPropagation();
+        dispatch(evt, { id: c.id });
+      });
+      return b;
+    };
+    if (c.status === "open") {
+      actions.appendChild(mkBtn("Reply", "reply", "comments:reply-request"));
+      actions.appendChild(mkBtn("Edit", "edit", "comments:edit-request"));
+      if (c.type === "suggestion" && c.proposed_replacement) {
+        actions.appendChild(mkBtn("Apply", "apply", "comments:apply-request"));
+      }
+      actions.appendChild(
+        mkBtn("Resolve", "resolve", "comments:resolve-request"),
+      );
+      actions.appendChild(mkBtn("Reject", "reject", "comments:reject-request"));
+    } else {
+      actions.appendChild(mkBtn("Reopen", "reopen", "comments:reopen-request"));
+      actions.appendChild(mkBtn("Edit", "edit", "comments:edit-request"));
+    }
+    card.appendChild(actions);
+
+    root.appendChild(card);
+  }
+  return root;
+}
+
+const commentsHoverTooltip = hoverTooltip(
+  (view, pos): Tooltip | null => {
+    const state = view.state.field(commentsStateField, false);
+    if (!state) return null;
+    const matches = commentsAt(state, pos);
+    if (matches.length === 0) return null;
+    // Anchor the tooltip on the first match's start
+    const first = matches[0];
+    return {
+      pos: Math.max(
+        0,
+        Math.min(first.anchor.char_start, view.state.doc.length),
+      ),
+      end: Math.max(
+        first.anchor.char_start,
+        Math.min(first.anchor.char_end, view.state.doc.length),
+      ),
+      above: true,
+      arrow: true,
+      create: () => {
+        const dom = renderTooltipBody(matches);
+        return { dom };
+      },
+    };
+  },
+  { hideOnChange: true, hoverTime: 250 },
+);
+
+// ---------- Gutter markers ----------
+
+class CommentGutterMarker extends GutterMarker {
+  constructor(private readonly comment: Comment) {
+    super();
+  }
+  eq(other: GutterMarker): boolean {
+    return (
+      other instanceof CommentGutterMarker &&
+      other.comment.id === this.comment.id &&
+      other.comment.status === this.comment.status &&
+      other.comment.type === this.comment.type
+    );
+  }
+  toDOM(): Node {
+    const dot = document.createElement("span");
+    const palette =
+      this.comment.status === "resolved" || this.comment.status === "applied"
+        ? "cmp-gutter-resolved"
+        : this.comment.status === "orphaned"
+          ? "cmp-gutter-orphan"
+          : this.comment.type === "suggestion"
+            ? "cmp-gutter-sug"
+            : "cmp-gutter-open";
+    const authorClass =
+      this.comment.author === "claude"
+        ? "cmp-gutter-author-claude"
+        : "cmp-gutter-author-user";
+    dot.className = `cmp-gutter-dot ${palette} ${authorClass}`;
+    dot.title = `${this.comment.author}: ${(this.comment.comment || "(no body)").slice(0, 120)}`;
+    const c = this.comment;
+    dot.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      window.dispatchEvent(
+        new CustomEvent("comments:focus-in-panel", { detail: { id: c.id } }),
+      );
+      window.dispatchEvent(
+        new CustomEvent("comments:jump", {
+          detail: { from: c.anchor.char_start, to: c.anchor.char_end },
+        }),
+      );
+    });
+    return dot;
+  }
+}
+
+const commentsGutter = gutter({
+  class: "cmp-gutter-col",
+  markers(view) {
+    const state = view.state.field(commentsStateField, false);
+    const builder = new RangeSetBuilder<GutterMarker>();
+    if (!state) return builder.finish();
+    const docLen = view.state.doc.length;
+    const seenLines = new Set<number>();
+    const sorted = [...state.comments]
+      .filter((c) => c.status !== "rejected")
+      .sort((a, b) => a.anchor.char_start - b.anchor.char_start);
+    for (const c of sorted) {
+      const start = Math.max(0, Math.min(c.anchor.char_start, docLen));
+      const line = view.state.doc.lineAt(start);
+      if (seenLines.has(line.number)) continue;
+      seenLines.add(line.number);
+      builder.add(line.from, line.from, new CommentGutterMarker(c));
+    }
+    return builder.finish();
+  },
+});
+
+// ---------- Click → focus in panel ----------
+
+const clickToFocusInPanel = EditorView.domEventHandlers({
+  click: (event, _view) => {
+    const target = event.target as HTMLElement | null;
+    if (!target) return false;
+    const anchorEl = target.closest("[data-comment-id]");
+    if (!anchorEl) return false;
+    const id = anchorEl.getAttribute("data-comment-id");
+    if (!id) return false;
+    dispatch("comments:focus-in-panel", { id });
+    return false; // do not preventDefault — let the click also place cursor
+  },
+});
+
+// ---------- Theme ----------
+
+export const commentsTheme = EditorView.theme({
+  // Default (user) colors — overridden by author classes below.
+  ".cmp-comment-open": {
+    backgroundColor: "rgba(252, 211, 77, 0.32)",
+    borderBottom: "2px solid rgba(245, 158, 11, 0.85)",
+    cursor: "pointer",
+  },
+  ".cmp-comment-suggestion": {
+    backgroundColor: "rgba(56, 189, 248, 0.28)",
+    borderBottom: "2px solid rgba(14, 165, 233, 0.85)",
+    cursor: "pointer",
+  },
+  // Claude-authored: violet/indigo palette so the user can tell at a glance
+  // who wrote what.
+  ".cmp-comment-open.cmp-author-claude": {
+    backgroundColor: "rgba(167, 139, 250, 0.30)", // violet-400/30
+    borderBottom: "2px solid rgba(124, 58, 237, 0.85)", // violet-600
+  },
+  ".cmp-comment-suggestion.cmp-author-claude": {
+    backgroundColor: "rgba(129, 140, 248, 0.30)", // indigo-400/30
+    borderBottom: "2px solid rgba(79, 70, 229, 0.85)", // indigo-600
+  },
+  ".cmp-comment-resolved": {
+    backgroundColor: "rgba(134, 239, 172, 0.22)",
+    borderBottom: "2px dashed rgba(74, 222, 128, 0.6)",
+    cursor: "pointer",
+  },
+  ".cmp-comment-orphan": {
+    backgroundColor: "rgba(244, 114, 182, 0.22)",
+    borderBottom: "2px dotted rgba(236, 72, 153, 0.7)",
+    cursor: "pointer",
+  },
+  ".cmp-comment-rejected": {
+    backgroundColor: "transparent",
+    borderBottom: "none",
+  },
+
+  // ---- tooltip ----
+  ".cm-tooltip:has(.cmp-tooltip)": {
+    backgroundColor: "transparent",
+    border: "none",
+    padding: "0",
+  },
+  ".cmp-tooltip": {
+    display: "flex",
+    flexDirection: "column",
+    gap: "6px",
+    maxWidth: "360px",
+    fontFamily: "system-ui, -apple-system, sans-serif",
+    fontSize: "12px",
+    color: "var(--foreground, #111)",
+  },
+  ".cmp-tooltip-card": {
+    backgroundColor: "var(--popover, #fff)",
+    color: "var(--popover-foreground, #111)",
+    border: "1px solid var(--border, rgba(0,0,0,0.1))",
+    borderRadius: "8px",
+    padding: "8px 10px",
+    boxShadow: "0 8px 24px rgba(0,0,0,0.18)",
+    borderLeft: "3px solid rgba(245, 158, 11, 0.85)",
+  },
+  ".cmp-tooltip-card-sug": {
+    borderLeft: "3px solid rgba(14, 165, 233, 0.85)",
+  },
+  ".cmp-tooltip-card-claude": {
+    borderLeft: "3px solid rgba(124, 58, 237, 0.85)",
+  },
+  ".cmp-tooltip-card-claude.cmp-tooltip-card-sug": {
+    borderLeft: "3px solid rgba(79, 70, 229, 0.85)",
+  },
+  ".cmp-tooltip-chip": {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "16px",
+    height: "16px",
+    borderRadius: "50%",
+    fontSize: "9px",
+    fontWeight: "700",
+    color: "#fff",
+    fontFamily: "system-ui, -apple-system, sans-serif",
+    flexShrink: "0",
+  },
+  ".cmp-tooltip-chip-user": {
+    backgroundColor: "rgb(217, 119, 6)",
+  },
+  ".cmp-tooltip-chip-claude": {
+    backgroundColor: "rgb(124, 58, 237)",
+  },
+  ".cmp-tooltip-header": {
+    display: "flex",
+    alignItems: "center",
+    gap: "6px",
+    marginBottom: "4px",
+    fontSize: "11px",
+  },
+  ".cmp-tooltip-type": {
+    fontWeight: "600",
+    textTransform: "uppercase",
+    letterSpacing: "0.04em",
+    color: "var(--muted-foreground, #555)",
+    fontSize: "10px",
+  },
+  ".cmp-tooltip-author": {
+    fontWeight: "600",
+  },
+  ".cmp-tooltip-time": {
+    color: "var(--muted-foreground, #777)",
+    fontSize: "10px",
+  },
+  ".cmp-tooltip-status": {
+    marginLeft: "auto",
+    padding: "1px 6px",
+    borderRadius: "10px",
+    fontSize: "10px",
+    fontWeight: "600",
+    textTransform: "uppercase",
+    letterSpacing: "0.04em",
+  },
+  ".cmp-tooltip-status-resolved": {
+    backgroundColor: "rgba(134, 239, 172, 0.3)",
+    color: "rgb(22, 101, 52)",
+  },
+  ".cmp-tooltip-status-applied": {
+    backgroundColor: "rgba(134, 239, 172, 0.3)",
+    color: "rgb(22, 101, 52)",
+  },
+  ".cmp-tooltip-status-rejected": {
+    backgroundColor: "rgba(228, 228, 231, 0.5)",
+    color: "rgb(82, 82, 91)",
+  },
+  ".cmp-tooltip-status-orphaned": {
+    backgroundColor: "rgba(244, 114, 182, 0.3)",
+    color: "rgb(157, 23, 77)",
+  },
+  ".cmp-tooltip-body": {
+    whiteSpace: "pre-wrap",
+    wordBreak: "break-word",
+    lineHeight: "1.4",
+  },
+  ".cmp-tooltip-sug": {
+    marginTop: "6px",
+    padding: "6px 8px",
+    backgroundColor: "rgba(14, 165, 233, 0.08)",
+    border: "1px solid rgba(14, 165, 233, 0.25)",
+    borderRadius: "6px",
+  },
+  ".cmp-tooltip-sug-label": {
+    fontSize: "9px",
+    fontWeight: "600",
+    textTransform: "uppercase",
+    color: "rgb(3, 105, 161)",
+    marginBottom: "2px",
+  },
+  ".cmp-tooltip-sug-body": {
+    fontFamily: "ui-monospace, monospace",
+    fontSize: "11px",
+    whiteSpace: "pre-wrap",
+    wordBreak: "break-word",
+    margin: "0",
+    lineHeight: "1.35",
+  },
+  ".cmp-tooltip-replies": {
+    marginTop: "6px",
+    paddingLeft: "8px",
+    borderLeft: "2px solid var(--border, rgba(0,0,0,0.1))",
+    display: "flex",
+    flexDirection: "column",
+    gap: "4px",
+  },
+  ".cmp-tooltip-reply-head": {
+    display: "flex",
+    gap: "4px",
+    fontSize: "10px",
+    color: "var(--muted-foreground, #777)",
+  },
+  ".cmp-tooltip-reply-author": {
+    fontWeight: "600",
+    color: "var(--foreground, #111)",
+  },
+  ".cmp-tooltip-reply-body": {
+    whiteSpace: "pre-wrap",
+    wordBreak: "break-word",
+    fontSize: "12px",
+    lineHeight: "1.35",
+  },
+  ".cmp-tooltip-actions": {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: "4px",
+    marginTop: "8px",
+    paddingTop: "6px",
+    borderTop: "1px solid var(--border, rgba(0,0,0,0.08))",
+  },
+  ".cmp-tooltip-btn": {
+    appearance: "none",
+    border: "1px solid var(--border, rgba(0,0,0,0.15))",
+    background: "transparent",
+    color: "var(--foreground, #111)",
+    padding: "2px 8px",
+    borderRadius: "4px",
+    fontSize: "11px",
+    fontFamily: "inherit",
+    cursor: "pointer",
+    transition: "background 80ms ease",
+  },
+  ".cmp-tooltip-btn:hover": {
+    background: "var(--accent, rgba(0,0,0,0.06))",
+  },
+  ".cmp-tooltip-btn-apply": {
+    color: "rgb(3, 105, 161)",
+    borderColor: "rgba(14, 165, 233, 0.5)",
+  },
+  ".cmp-tooltip-btn-resolve": {
+    color: "rgb(22, 101, 52)",
+    borderColor: "rgba(74, 222, 128, 0.55)",
+  },
+  ".cmp-tooltip-btn-reject": {
+    color: "rgb(127, 29, 29)",
+    borderColor: "rgba(248, 113, 113, 0.55)",
+  },
+
+  // ---- gutter ----
+  ".cmp-gutter-col": {
+    width: "12px",
+    minWidth: "12px",
+  },
+  ".cmp-gutter-dot": {
+    display: "block",
+    width: "6px",
+    height: "6px",
+    margin: "5px auto 0",
+    borderRadius: "50%",
+    cursor: "pointer",
+    boxShadow: "0 0 0 1px rgba(0,0,0,0.06)",
+  },
+  ".cmp-gutter-open": {
+    backgroundColor: "rgb(245, 158, 11)",
+  },
+  ".cmp-gutter-sug": {
+    backgroundColor: "rgb(14, 165, 233)",
+  },
+  ".cmp-gutter-resolved": {
+    backgroundColor: "rgb(74, 222, 128)",
+  },
+  ".cmp-gutter-orphan": {
+    backgroundColor: "rgb(236, 72, 153)",
+  },
+  // Author-specific overrides for the dot (Claude = violet/indigo)
+  ".cmp-gutter-open.cmp-gutter-author-claude": {
+    backgroundColor: "rgb(124, 58, 237)", // violet-600
+  },
+  ".cmp-gutter-sug.cmp-gutter-author-claude": {
+    backgroundColor: "rgb(79, 70, 229)", // indigo-600
+  },
+});
+
+export const commentsExtension = [
+  commentsStateField,
+  commentsHoverTooltip,
+  clickToFocusInPanel,
+  commentsGutter,
+  commentsTheme,
+];

--- a/apps/desktop/src/components/workspace/editor/latex-editor.tsx
+++ b/apps/desktop/src/components/workspace/editor/latex-editor.tsx
@@ -81,6 +81,10 @@ import { ProblemsPanel, type DiagnosticItem } from "./problems-panel";
 import { PdfViewer } from "@/components/workspace/preview/pdf-viewer";
 import { readFile } from "@tauri-apps/plugin-fs";
 import { createLogger } from "@/lib/debug/logger";
+import { commentsExtension, setCommentsEffect } from "./comments-extension";
+import { CommentComposer } from "./comment-composer";
+import { useCommentsStore } from "@/stores/comments-store";
+import { MessageSquareIcon, LightbulbIcon } from "lucide-react";
 
 const log = createLogger("merge-view");
 
@@ -670,6 +674,7 @@ export function LatexEditor() {
         search(),
         highlightSelectionMatches(),
         mergeCompartmentRef.current.of([]),
+        ...commentsExtension,
         updateListener,
         EditorView.lineWrapping,
         scrollPastEnd(),
@@ -933,6 +938,172 @@ export function LatexEditor() {
     clearJumpRequest();
   }, [jumpToPosition, clearJumpRequest]);
 
+  // === Comments: attach/detach the store to the current project ===
+  useEffect(() => {
+    if (!projectRoot) return;
+    useCommentsStore
+      .getState()
+      .attachToProject(projectRoot)
+      .catch((e) => log.error("comments attach failed", { error: String(e) }));
+    return () => {
+      useCommentsStore
+        .getState()
+        .detach()
+        .catch(() => {});
+    };
+  }, [projectRoot]);
+
+  // === Comments: re-dispatch decoration set when comments for the active
+  //     file change. The CodeMirror StateField only renders what we feed it. ===
+  const allComments = useCommentsStore((s) => s.comments);
+  const activeFileRelPath = activeFile?.relativePath ?? null;
+  const commentsForActiveFile = useMemo(
+    () =>
+      activeFileRelPath
+        ? allComments.filter((c) => c.file_path === activeFileRelPath)
+        : [],
+    [allComments, activeFileRelPath],
+  );
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    view.dispatch({
+      effects: setCommentsEffect.of(commentsForActiveFile),
+    });
+  }, [commentsForActiveFile]);
+
+  // === Comments: dispatch active-comment-id based on cursor position so the
+  //     sidebar can highlight the matching row. ===
+  const cursorPosition = useDocumentStore((s) => s.cursorPosition);
+  useEffect(() => {
+    if (!activeFileRelPath) {
+      window.dispatchEvent(
+        new CustomEvent("comments:active-set", { detail: { id: null } }),
+      );
+      return;
+    }
+    const hit = commentsForActiveFile.find(
+      (c) =>
+        c.status !== "rejected" &&
+        c.anchor.char_start <= cursorPosition &&
+        cursorPosition <= c.anchor.char_end,
+    );
+    window.dispatchEvent(
+      new CustomEvent("comments:active-set", {
+        detail: { id: hit?.id ?? null },
+      }),
+    );
+  }, [cursorPosition, commentsForActiveFile, activeFileRelPath]);
+
+  // === Comments: keyboard shortcuts (Cmd+Shift+M / Cmd+Shift+S) ===
+  // Uses a ref so we can reference handleToolbarAction (declared later in
+  // the function) without TDZ issues.
+  const toolbarActionRef = useRef<((actionId: string) => void) | null>(null);
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || !e.shiftKey) return;
+      const key = e.key.toLowerCase();
+      if (key !== "m" && key !== "s") return;
+      const view = viewRef.current;
+      if (!view) return;
+      const active = document.activeElement;
+      const editorDom = view.dom;
+      if (active && active !== document.body && !editorDom.contains(active)) {
+        return;
+      }
+      const sel = view.state.selection.main;
+      if (sel.empty) return;
+      e.preventDefault();
+      toolbarActionRef.current?.(key === "s" ? "suggest" : "comment");
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  // === Comments: open the composer from a PDF-side selection. The
+  //     pdf-preview component resolved the source location via SyncTeX
+  //     and pre-computed the anchor; we just pop the composer here. ===
+  useEffect(() => {
+    const onStartFromPdf = (e: Event) => {
+      const detail = (
+        e as CustomEvent<{
+          mode: "comment" | "suggestion";
+          filePath: string;
+          anchor: {
+            line_start: number;
+            line_end: number;
+            char_start: number;
+            char_end: number;
+            quoted_text: string;
+          };
+        }>
+      ).detail;
+      if (!detail) return;
+      setComposerState({
+        open: true,
+        mode: detail.mode,
+        filePath: detail.filePath,
+        anchor: detail.anchor,
+      });
+    };
+    window.addEventListener(
+      "comments:start-from-pdf",
+      onStartFromPdf as EventListener,
+    );
+    return () =>
+      window.removeEventListener(
+        "comments:start-from-pdf",
+        onStartFromPdf as EventListener,
+      );
+  }, []);
+
+  // === Comments: listen for "jump to comment" + "apply suggestion" events
+  //     dispatched by the CommentsPanel sidebar. ===
+  useEffect(() => {
+    const onJump = (e: Event) => {
+      const view = viewRef.current;
+      if (!view) return;
+      const detail = (e as CustomEvent<{ from: number; to: number }>).detail;
+      if (!detail) return;
+      const docLen = view.state.doc.length;
+      const from = Math.max(0, Math.min(detail.from, docLen));
+      const to = Math.max(from, Math.min(detail.to, docLen));
+      view.dispatch({
+        selection: { anchor: from, head: to },
+        effects: EditorView.scrollIntoView(from, { y: "center" }),
+      });
+      view.focus();
+    };
+    const onApply = (e: Event) => {
+      const view = viewRef.current;
+      if (!view) return;
+      const detail = (
+        e as CustomEvent<{ from: number; to: number; replacement: string }>
+      ).detail;
+      if (!detail) return;
+      const docLen = view.state.doc.length;
+      const from = Math.max(0, Math.min(detail.from, docLen));
+      const to = Math.max(from, Math.min(detail.to, docLen));
+      view.dispatch({
+        changes: { from, to, insert: detail.replacement },
+        selection: { anchor: from + detail.replacement.length },
+      });
+      view.focus();
+    };
+    window.addEventListener("comments:jump", onJump as EventListener);
+    window.addEventListener(
+      "comments:apply-suggestion",
+      onApply as EventListener,
+    );
+    return () => {
+      window.removeEventListener("comments:jump", onJump as EventListener);
+      window.removeEventListener(
+        "comments:apply-suggestion",
+        onApply as EventListener,
+      );
+    };
+  }, []);
+
   // Selection toolbar: compute context label and container-relative position
   const selectionRange = useDocumentStore((s) => s.selectionRange);
   const selectionLabel = useMemo(() => {
@@ -981,12 +1152,61 @@ export function LatexEditor() {
         label: "Proofread",
         icon: <SpellCheckIcon className="size-4" />,
       },
+      {
+        id: "comment",
+        label: "Comment",
+        icon: <MessageSquareIcon className="size-4" />,
+      },
+      {
+        id: "suggest",
+        label: "Suggest",
+        icon: <LightbulbIcon className="size-4" />,
+      },
     ],
     [],
   );
 
+  const [composerState, setComposerState] = useState<{
+    open: boolean;
+    mode: "comment" | "suggestion";
+    filePath: string;
+    anchor: {
+      line_start: number;
+      line_end: number;
+      char_start: number;
+      char_end: number;
+      quoted_text: string;
+    };
+  } | null>(null);
+
   const handleToolbarAction = useCallback(
     (actionId: string) => {
+      if (actionId === "comment" || actionId === "suggest") {
+        const view = viewRef.current;
+        const docState = useDocumentStore.getState();
+        const file = docState.files.find((f) => f.id === docState.activeFileId);
+        const sel = view?.state.selection.main;
+        if (!view || !file || !sel || sel.empty) return;
+        const startLine = view.state.doc.lineAt(sel.from);
+        const endLine = view.state.doc.lineAt(sel.to);
+        const quoted = view.state.doc.sliceString(sel.from, sel.to);
+        setComposerState({
+          open: true,
+          mode: actionId === "suggest" ? "suggestion" : "comment",
+          filePath: file.relativePath,
+          anchor: {
+            line_start: startLine.number,
+            line_end: endLine.number,
+            char_start: sel.from,
+            char_end: sel.to,
+            quoted_text: quoted,
+          },
+        });
+        // Dismiss the toolbar but keep selection visible behind the dialog
+        toolbarStickyRef.current = false;
+        setSelectionCoords(null);
+        return;
+      }
       toolbarStickyRef.current = false;
       setSelectionCoords(null);
       setSelectionRange(null);
@@ -1004,6 +1224,11 @@ export function LatexEditor() {
     setSelectionCoords(null);
     setSelectionRange(null);
   }, [setSelectionRange]);
+
+  // Keep the keyboard-shortcut ref in sync with the latest handleToolbarAction
+  useEffect(() => {
+    toolbarActionRef.current = handleToolbarAction;
+  }, [handleToolbarAction]);
 
   // History review action handlers
   const handleHistoryRestore = useCallback(async () => {
@@ -1193,6 +1418,42 @@ export function LatexEditor() {
                   onDismiss={handleToolbarDismiss}
                 />
               )}
+            {composerState?.open && (
+              <CommentComposer
+                open={composerState.open}
+                mode={composerState.mode}
+                quotedText={composerState.anchor.quoted_text}
+                initialReplacement={
+                  composerState.mode === "suggestion"
+                    ? composerState.anchor.quoted_text
+                    : undefined
+                }
+                onCancel={() => {
+                  setComposerState(null);
+                  setSelectionRange(null);
+                }}
+                onSubmit={async ({ comment, replacement }) => {
+                  const snap = composerState;
+                  if (!snap) return;
+                  try {
+                    await useCommentsStore.getState().addComment({
+                      filePath: snap.filePath,
+                      anchor: snap.anchor,
+                      type: snap.mode,
+                      author: "user",
+                      comment,
+                      proposedReplacement:
+                        snap.mode === "suggestion" ? replacement : null,
+                    });
+                  } catch (e) {
+                    log.error("add comment failed", { error: String(e) });
+                  } finally {
+                    setComposerState(null);
+                    setSelectionRange(null);
+                  }
+                }}
+              />
+            )}
             {activeFileChange && mergeChunkInfo.total > 0 && (
               <div className="absolute top-3 right-3 z-20 flex items-center gap-1 rounded-lg border border-border bg-background/95 px-2 py-1 shadow-lg backdrop-blur-sm">
                 <span className="px-1 font-mono text-muted-foreground text-xs">

--- a/apps/desktop/src/components/workspace/preview/pdf-preview.tsx
+++ b/apps/desktop/src/components/workspace/preview/pdf-preview.tsx
@@ -13,6 +13,8 @@ import {
   CrosshairIcon,
   ChevronUpIcon,
   ChevronDownIcon,
+  MessageSquareIcon,
+  LightbulbIcon,
 } from "lucide-react";
 import { writeFile, mkdir, exists } from "@tauri-apps/plugin-fs";
 import { join } from "@tauri-apps/api/path";
@@ -338,6 +340,16 @@ export function PdfPreview() {
   const pdfToolbarActions: ToolbarAction[] = useMemo(
     () => [
       {
+        id: "pdf-comment",
+        label: "Comment",
+        icon: <MessageSquareIcon className="size-4" />,
+      },
+      {
+        id: "pdf-suggest",
+        label: "Suggest",
+        icon: <LightbulbIcon className="size-4" />,
+      },
+      {
         id: "proofread",
         label: "Proofread",
         icon: <SpellCheckIcon className="size-4" />,
@@ -357,6 +369,89 @@ export function PdfPreview() {
       if (!pdfSelection) return;
       const label = pdfContextLabel;
       const sel = pdfSelection;
+
+      // --- New: PDF-side commenting on selected text ---
+      if (actionId === "pdf-comment" || actionId === "pdf-suggest") {
+        if (!resolvedSource) {
+          // Synctex couldn't map this region to source. Tell the user.
+          // (The lookup may still be in-flight if the selection was very fresh.)
+          import("sonner").then(({ toast }) => {
+            toast.error(
+              "Couldn't locate the source for this PDF selection. " +
+                "Try again, or use the Navigate button to jump first.",
+            );
+          });
+          return;
+        }
+        const normalize = (p: string) =>
+          p.replace(/\\/g, "/").replace(/^\.\//, "");
+        const target = files.find(
+          (f) => normalize(f.relativePath) === normalize(resolvedSource.file),
+        );
+        if (!target) {
+          import("sonner").then(({ toast }) => {
+            toast.error(`Source file not in project: ${resolvedSource.file}`);
+          });
+          return;
+        }
+        const fileContent = target.content ?? "";
+        const lines = fileContent.split("\n");
+        const lineIdx = Math.max(
+          0,
+          Math.min(resolvedSource.line - 1, lines.length - 1),
+        );
+        const line = lines[lineIdx] ?? "";
+
+        // Compute absolute offset of the start of the synctex line
+        let lineStartOffset = 0;
+        for (let i = 0; i < lineIdx; i++)
+          lineStartOffset += lines[i].length + 1;
+
+        // Try to find the selected text within the resolved line. Fall back
+        // to anchoring on the whole line if not found.
+        const selText = sel.text.trim();
+        let charStart = lineStartOffset;
+        let charEnd = lineStartOffset + line.length;
+        let quoted = line;
+        if (selText) {
+          const idx = line.indexOf(selText);
+          if (idx >= 0) {
+            charStart = lineStartOffset + idx;
+            charEnd = charStart + selText.length;
+            quoted = selText;
+          }
+        }
+
+        // Switch to the target file if needed, then dispatch
+        const needsSwitch =
+          useDocumentStore.getState().activeFileId !== target.id;
+        if (needsSwitch) setActiveFile(target.id);
+
+        setPdfSelection(null);
+        window.getSelection()?.removeAllRanges();
+
+        const dispatchEvent = () => {
+          window.dispatchEvent(
+            new CustomEvent("comments:start-from-pdf", {
+              detail: {
+                mode: actionId === "pdf-suggest" ? "suggestion" : "comment",
+                filePath: target.relativePath,
+                anchor: {
+                  line_start: lineIdx + 1,
+                  line_end: lineIdx + 1,
+                  char_start: charStart,
+                  char_end: charEnd,
+                  quoted_text: quoted,
+                },
+              },
+            }),
+          );
+        };
+        if (needsSwitch) setTimeout(dispatchEvent, 100);
+        else dispatchEvent();
+        return;
+      }
+
       setPdfSelection(null);
       window.getSelection()?.removeAllRanges();
       if (actionId === "proofread") {
@@ -377,6 +472,8 @@ export function PdfPreview() {
       resolvedSource,
       navigateToSource,
       buildPdfContext,
+      files,
+      setActiveFile,
     ],
   );
 

--- a/apps/desktop/src/components/workspace/sidebar.tsx
+++ b/apps/desktop/src/components/workspace/sidebar.tsx
@@ -44,6 +44,11 @@ import { useDocumentStore, type ProjectFile } from "@/stores/document-store";
 import { useHistoryStore } from "@/stores/history-store";
 import { cn } from "@/lib/utils";
 import { ZoteroPanel, ZoteroHeader } from "@/components/workspace/zotero-panel";
+import {
+  CommentsPanel,
+  CommentsHeader,
+} from "@/components/workspace/comments-panel";
+import { useCommentsStore } from "@/stores/comments-store";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -795,13 +800,27 @@ export function Sidebar() {
         <PanelResizeHandle className="h-px bg-sidebar-border transition-colors hover:bg-ring data-resize-handle-active:bg-ring" />
 
         {/* Zotero */}
-        <Panel defaultSize={15} minSize={10}>
+        <Panel defaultSize={12} minSize={8}>
           <div className="flex h-full flex-col">
             <div className="flex h-8 shrink-0 items-center">
               <ZoteroHeader />
             </div>
             <div className="min-h-0 flex-1 overflow-hidden">
               <ZoteroPanel />
+            </div>
+          </div>
+        </Panel>
+
+        <PanelResizeHandle className="h-px bg-sidebar-border transition-colors hover:bg-ring data-resize-handle-active:bg-ring" />
+
+        {/* Comments */}
+        <Panel defaultSize={18} minSize={10}>
+          <div className="flex h-full flex-col">
+            <div className="flex h-8 shrink-0 items-center">
+              <CommentsHeader />
+            </div>
+            <div className="min-h-0 flex-1 overflow-hidden">
+              <CommentsPanel />
             </div>
           </div>
         </Panel>
@@ -1149,9 +1168,10 @@ function FileTreeNode({
           >
             {getFileIcon(file)}
             <span className="min-w-0 flex-1 truncate">{node.name}</span>
+            <FileCommentBadge filePath={file.relativePath} />
             {file.isDirty && (
               <span
-                className="ml-auto size-2 shrink-0 rounded-full bg-blue-500"
+                className="size-2 shrink-0 rounded-full bg-blue-500"
                 title="Modified"
               />
             )}
@@ -1173,6 +1193,40 @@ function FileTreeNode({
         </ContextMenuContent>
       </ContextMenu>
     </DraggableItem>
+  );
+}
+
+// ─── File-tree comment count badge ───
+//
+// Small chip next to each file showing the open-comment count. Hidden when
+// there are no open comments. Click intentionally not handled separately —
+// the file row already handles selection.
+
+function FileCommentBadge({ filePath }: { filePath: string }) {
+  const count = useCommentsStore(
+    (s) =>
+      s.comments.filter((c) => c.file_path === filePath && c.status === "open")
+        .length,
+  );
+  const hasClaude = useCommentsStore((s) =>
+    s.comments.some(
+      (c) =>
+        c.file_path === filePath &&
+        c.status === "open" &&
+        c.author === "claude",
+    ),
+  );
+  if (count === 0) return null;
+  return (
+    <span
+      className={cn(
+        "flex h-4 min-w-[16px] items-center justify-center rounded-full px-1 font-bold text-[9px] text-white leading-none",
+        hasClaude ? "bg-violet-600" : "bg-amber-600",
+      )}
+      title={`${count} open comment${count === 1 ? "" : "s"}`}
+    >
+      {count}
+    </span>
   );
 }
 

--- a/apps/desktop/src/lib/tauri/comments.ts
+++ b/apps/desktop/src/lib/tauri/comments.ts
@@ -1,0 +1,110 @@
+// Tauri command wrappers + types for the per-passage comments feature.
+// Mirrors the Rust schema in apps/desktop/src-tauri/src/comments.rs.
+
+import { invoke } from "@tauri-apps/api/core";
+
+export interface CommentAnchor {
+  line_start: number;
+  line_end: number;
+  char_start: number;
+  char_end: number;
+  quoted_text: string;
+}
+
+export interface Reply {
+  author: string;
+  body: string;
+  ts: string;
+}
+
+export type CommentStatus =
+  | "open"
+  | "resolved"
+  | "rejected"
+  | "applied"
+  | "orphaned";
+export type CommentType = "comment" | "suggestion";
+
+export interface Comment {
+  id: string;
+  file_path: string;
+  anchor: CommentAnchor;
+  type: CommentType;
+  author: string;
+  comment: string;
+  proposed_replacement: string | null;
+  status: CommentStatus;
+  replies: Reply[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AddCommentInput {
+  projectRoot: string;
+  filePath: string;
+  anchor: CommentAnchor;
+  type: CommentType;
+  author: string;
+  comment: string;
+  proposedReplacement: string | null;
+}
+
+export async function listComments(projectRoot: string): Promise<Comment[]> {
+  return invoke<Comment[]>("comments_list", { projectRoot });
+}
+
+export async function addComment(input: AddCommentInput): Promise<Comment> {
+  return invoke<Comment>("comments_add", {
+    input: {
+      project_root: input.projectRoot,
+      file_path: input.filePath,
+      anchor: input.anchor,
+      type: input.type,
+      author: input.author,
+      comment: input.comment,
+      proposed_replacement: input.proposedReplacement,
+    },
+  });
+}
+
+export interface UpdateCommentInput {
+  projectRoot: string;
+  id: string;
+  patch: Partial<Pick<Comment, "comment" | "proposed_replacement" | "status">>;
+}
+
+export async function updateComment(
+  input: UpdateCommentInput,
+): Promise<Comment> {
+  return invoke<Comment>("comments_update", {
+    input: {
+      project_root: input.projectRoot,
+      id: input.id,
+      patch: input.patch,
+    },
+  });
+}
+
+export async function replyToComment(args: {
+  projectRoot: string;
+  id: string;
+  author: string;
+  body: string;
+}): Promise<Comment> {
+  return invoke<Comment>("comments_reply", {
+    input: {
+      project_root: args.projectRoot,
+      id: args.id,
+      author: args.author,
+      body: args.body,
+    },
+  });
+}
+
+export async function startCommentsWatcher(projectRoot: string): Promise<void> {
+  return invoke<void>("comments_start_watcher", { projectRoot });
+}
+
+export async function stopCommentsWatcher(): Promise<void> {
+  return invoke<void>("comments_stop_watcher");
+}

--- a/apps/desktop/src/stores/comments-store.ts
+++ b/apps/desktop/src/stores/comments-store.ts
@@ -1,0 +1,271 @@
+// Zustand store for the per-passage comments feature.
+//
+// Subscribes to the backend `comments-changed` event so external writes
+// (e.g. a Claude Code terminal session) appear live. On every refresh
+// triggered by an event, detects new comments or replies authored by a
+// remote actor and fires a sonner toast so the user notices.
+
+import { create } from "zustand";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { toast } from "sonner";
+import {
+  type Comment,
+  type AddCommentInput,
+  type UpdateCommentInput,
+  listComments,
+  addComment as backendAdd,
+  updateComment as backendUpdate,
+  replyToComment as backendReply,
+  startCommentsWatcher,
+  stopCommentsWatcher,
+} from "@/lib/tauri/comments";
+
+export const LOCAL_AUTHOR = "user";
+
+interface CommentsState {
+  projectRoot: string | null;
+  comments: Comment[];
+  loading: boolean;
+  error: string | null;
+
+  _unlisten: UnlistenFn | null;
+  // Snapshot of (commentId -> reply count) used to diff after an external
+  // refresh and decide whether to fire a toast.
+  _replyCountById: Map<string, number>;
+  _seenCommentIds: Set<string>;
+
+  attachToProject: (projectRoot: string) => Promise<void>;
+  detach: () => Promise<void>;
+  refresh: (options?: { silent?: boolean }) => Promise<void>;
+
+  addComment: (input: Omit<AddCommentInput, "projectRoot">) => Promise<Comment>;
+  updateComment: (
+    id: string,
+    patch: UpdateCommentInput["patch"],
+  ) => Promise<Comment>;
+  reply: (id: string, body: string, author?: string) => Promise<Comment>;
+
+  byFile: (filePath: string) => Comment[];
+  openCount: () => number;
+}
+
+function snapshotReplyCounts(comments: Comment[]): Map<string, number> {
+  const m = new Map<string, number>();
+  for (const c of comments) m.set(c.id, c.replies.length);
+  return m;
+}
+
+function snapshotIds(comments: Comment[]): Set<string> {
+  return new Set(comments.map((c) => c.id));
+}
+
+function fileShortName(filePath: string): string {
+  const i = Math.max(filePath.lastIndexOf("/"), filePath.lastIndexOf("\\"));
+  return i >= 0 ? filePath.slice(i + 1) : filePath;
+}
+
+function summarizeBody(body: string): string {
+  const trimmed = body.trim().replace(/\s+/g, " ");
+  return trimmed.length > 80 ? `${trimmed.slice(0, 80)}...` : trimmed;
+}
+
+export const useCommentsStore = create<CommentsState>()((set, get) => ({
+  projectRoot: null,
+  comments: [],
+  loading: false,
+  error: null,
+  _unlisten: null,
+  _replyCountById: new Map(),
+  _seenCommentIds: new Set(),
+
+  attachToProject: async (projectRoot: string) => {
+    await get().detach();
+    set({ projectRoot, loading: true, error: null });
+
+    try {
+      const comments = await listComments(projectRoot);
+      set({
+        comments,
+        loading: false,
+        _replyCountById: snapshotReplyCounts(comments),
+        _seenCommentIds: snapshotIds(comments),
+      });
+    } catch (e) {
+      set({ error: String(e), loading: false });
+    }
+
+    try {
+      await startCommentsWatcher(projectRoot);
+    } catch (e) {
+      console.warn("[comments] failed to start watcher:", e);
+    }
+
+    try {
+      const unlisten = await listen<{ path: string }>(
+        "comments-changed",
+        async () => {
+          await get().refresh();
+        },
+      );
+      set({ _unlisten: unlisten });
+    } catch (e) {
+      console.warn("[comments] failed to listen:", e);
+    }
+  },
+
+  detach: async () => {
+    const { _unlisten } = get();
+    if (_unlisten) {
+      try {
+        _unlisten();
+      } catch {
+        /* noop */
+      }
+    }
+    try {
+      await stopCommentsWatcher();
+    } catch {
+      /* noop */
+    }
+    set({
+      projectRoot: null,
+      comments: [],
+      loading: false,
+      error: null,
+      _unlisten: null,
+      _replyCountById: new Map(),
+      _seenCommentIds: new Set(),
+    });
+  },
+
+  refresh: async (options) => {
+    const silent = options?.silent ?? false;
+    const root = get().projectRoot;
+    if (!root) return;
+    try {
+      const next = await listComments(root);
+
+      if (!silent) {
+        const prevIds = get()._seenCommentIds;
+        const prevReplyCounts = get()._replyCountById;
+
+        // New comments from remote
+        for (const c of next) {
+          if (!prevIds.has(c.id) && c.author !== LOCAL_AUTHOR) {
+            const label =
+              c.type === "suggestion"
+                ? `${c.author} suggested an edit on ${fileShortName(c.file_path)}:${c.anchor.line_start}`
+                : `${c.author} commented on ${fileShortName(c.file_path)}:${c.anchor.line_start}`;
+            toast.info(label, {
+              description: summarizeBody(c.comment || ""),
+              action: {
+                label: "Show",
+                onClick: () => {
+                  window.dispatchEvent(
+                    new CustomEvent("comments:focus-in-panel", {
+                      detail: { id: c.id },
+                    }),
+                  );
+                  window.dispatchEvent(
+                    new CustomEvent("comments:jump", {
+                      detail: {
+                        from: c.anchor.char_start,
+                        to: c.anchor.char_end,
+                      },
+                    }),
+                  );
+                },
+              },
+            });
+          }
+        }
+
+        // New replies on existing comments
+        for (const c of next) {
+          const before = prevReplyCounts.get(c.id) ?? 0;
+          if (c.replies.length > before) {
+            const newOnes = c.replies.slice(before);
+            for (const r of newOnes) {
+              if (r.author === LOCAL_AUTHOR) continue;
+              toast.info(
+                `${r.author} replied on ${fileShortName(c.file_path)}:${c.anchor.line_start}`,
+                {
+                  description: summarizeBody(r.body),
+                  action: {
+                    label: "Show",
+                    onClick: () => {
+                      window.dispatchEvent(
+                        new CustomEvent("comments:focus-in-panel", {
+                          detail: { id: c.id },
+                        }),
+                      );
+                    },
+                  },
+                },
+              );
+            }
+          }
+        }
+      }
+
+      set({
+        comments: next,
+        _replyCountById: snapshotReplyCounts(next),
+        _seenCommentIds: snapshotIds(next),
+      });
+    } catch (e) {
+      set({ error: String(e) });
+    }
+  },
+
+  addComment: async (input) => {
+    const root = get().projectRoot;
+    if (!root) throw new Error("No project open");
+    const added = await backendAdd({ ...input, projectRoot: root });
+    set((s) => {
+      const next = [...s.comments, added];
+      return {
+        comments: next,
+        _replyCountById: snapshotReplyCounts(next),
+        _seenCommentIds: snapshotIds(next),
+      };
+    });
+    return added;
+  },
+
+  updateComment: async (id, patch) => {
+    const root = get().projectRoot;
+    if (!root) throw new Error("No project open");
+    const updated = await backendUpdate({ projectRoot: root, id, patch });
+    set((s) => {
+      const next = s.comments.map((c) => (c.id === id ? updated : c));
+      return {
+        comments: next,
+        _replyCountById: snapshotReplyCounts(next),
+      };
+    });
+    return updated;
+  },
+
+  reply: async (id, body, author = LOCAL_AUTHOR) => {
+    const root = get().projectRoot;
+    if (!root) throw new Error("No project open");
+    const updated = await backendReply({ projectRoot: root, id, author, body });
+    set((s) => {
+      const next = s.comments.map((c) => (c.id === id ? updated : c));
+      return {
+        comments: next,
+        _replyCountById: snapshotReplyCounts(next),
+      };
+    });
+    return updated;
+  },
+
+  byFile: (filePath: string) => {
+    return get().comments.filter((c) => c.file_path === filePath);
+  },
+
+  openCount: () => {
+    return get().comments.filter((c) => c.status === "open").length;
+  },
+}));


### PR DESCRIPTION
## Status — Draft / RFC

Opening this as a draft to **gauge interest before iterating on PR shape**.
~2.7k LOC across 10 files. Happy to slice into smaller PRs, swap the
storage layer, add settings toggles, or restructure — whatever shape you'd
take this in.

## Motivation
ClaudePrism's core flow involves Claude Code working alongside the user
on a LaTeX project. Today, Claude's edits land as proposed-change diffs
in the editor, but there's no surface for *non-edit* feedback (questions,
suggestions, pointing out an inconsistency without rewriting the passage).
Comments give Claude and the user a shared margin: per-passage threads
that anchor to specific text ranges and survive document edits.

## Surface

**Editor**
- Selection toolbar gains "Comment" and "Suggest" actions
- Cmd+Shift+M (Comment) / Cmd+Shift+S (Suggest) keyboard shortcuts
- Commented passages get a decorated underline + gutter marker
- Hover popover shows the comment thread; clicking jumps to the panel

**Sidebar panel**
- New "Comments" panel below Zotero, with: search, sort, per-item replies,
  resolve/reject/apply-suggestion actions
- Active-comment row is highlighted based on editor cursor position

**PDF preview**
- "Comment" / "Suggest" buttons appear when text is selected in the PDF
- SyncTeX maps the PDF selection back to a source range, then opens the
  composer anchored to that range

**File tree**
- Per-file count badge (violet when Claude has commented, amber when
  only the user has)

## Architecture

\`\`\`
project_root/
  .claudeprism/
    comments.json          <- single-file storage, JSON
\`\`\`

- **Rust backend** (\`comments.rs\`): list/add/update/reply commands + a
  file watcher that re-emits to the frontend when the JSON changes
  externally (i.e. when Claude Code edits it)
- **TS bindings** (\`lib/tauri/comments.ts\`)
- **Zustand store** (\`stores/comments-store.ts\`): in-memory mirror,
  optimistic updates, project-scoped attach/detach
- **CodeMirror extension** (\`comments-extension.ts\`): decorations,
  gutter, hover popover, cursor<->active-comment sync
- **UI** (\`comments-panel.tsx\`, \`comment-composer.tsx\`)

Author identity is currently a simple \`'user' | 'claude'\` placeholder;
a real auth/identity model is clearly required before this lands properly.

## Why a file-based contract?
Lets Claude Code edit \`.claudeprism/comments.json\` directly via its own
file tools; no Tauri IPC required from Claude's side. The watcher
surfaces external edits in-app via toast. Trade-off: concurrent writes
are best-effort — fine for one-user-plus-Claude, not for multi-user.

## Open questions for maintainers
1. Is this a feature you'd want in upstream, or should it live on a fork?
2. Storage shape — JSON file ok, or SQLite preferred?
3. Slicing — happy to break this into 3-5 smaller PRs (backend / store /
   editor decorations / panel / PDF integration). Just say the word.
4. Settings toggle vs always-on?
5. Author identity model — does ClaudePrism have any user-identity
   concept I can reuse, or should I propose one?
6. The \`.claudeprism/\` directory name — fine, or do you have preferences?

## What's deliberately out of scope (for follow-ups)
- Markdown rendering in comment bodies (issue noted in code)
- Multi-user concurrent edit reconciliation
- Comment threading deeper than 1 level of replies

## Test plan
- [ ] Open a project, select text, "Comment" action -> composer opens ->
      submit -> comment renders in panel and as gutter marker
- [ ] Select text in the PDF preview, "Comment" -> SyncTeX resolves source
      location -> composer opens anchored to source
- [ ] Externally edit \`.claudeprism/comments.json\` (mimicking Claude
      Code) -> toast appears, panel updates
- [ ] Reply / resolve / apply-suggestion flows