### PR TITLE
fix: show selection highlight in vim visual mode

### DIFF
--- a/apps/desktop/src/components/workspace/editor/latex-editor.tsx
+++ b/apps/desktop/src/components/workspace/editor/latex-editor.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState, useMemo } from "react";
 import { Compartment, EditorState, Prec, Transaction } from "@codemirror/state";
 import {
   EditorView,
+  drawSelection,
   keymap,
   lineNumbers,
   highlightActiveLine,
@@ -620,6 +621,7 @@ export function LatexEditor() {
       extensions: [
         compileKeymap,
         lineNumbers(),
+        drawSelection(),
         highlightActiveLine(),
         highlightActiveLineGutter(),
         history(),


### PR DESCRIPTION
## Summary

- Adds `drawSelection()` to the CodeMirror extension list in `LatexEditor`
- Without this extension, vim visual mode selections were invisible — the `.cm-selectionBackground` CSS rule was already in place but had no elements to style
- Selection appearance is now consistent between vim and non-vim mode

## Test plan

- [ ] Enable vim mode, press `v` to enter visual mode and move the cursor to select text — selection highlight should be visible
- [ ] Disable vim mode, select text with mouse/keyboard — highlight should look the same