### PR TITLE
chore: bump version to 1.1.7

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-prism/desktop",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-prism-desktop"
-version = "1.1.6"
+version = "1.1.7"
 description = "AI-powered LaTeX writing workspace"
 edition = "2021"
 

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/nicegui-unofficial/nicegui-tauri-template/main/src-tauri/tauri.conf-v2-schema.json",
   "identifier": "com.claude-prism.desktop",
   "productName": "ClaudePrism",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",

--- a/apps/desktop/src/__tests__/lib/tauri-fs.test.ts
+++ b/apps/desktop/src/__tests__/lib/tauri-fs.test.ts
@@ -52,7 +52,7 @@ describe("tauri fs helpers", () => {
 
   describe("scanProjectFolder", () => {
     it("does not recurse into generated cache directories", async () => {
-      vi.mocked(readDir).mockImplementation(async (dir: string) => {
+      vi.mocked(readDir).mockImplementation(async (dir: string | URL) => {
         if (dir === "/project") {
           return [
             { name: "__pycache__", isDirectory: true },

--- a/apps/desktop/src/__tests__/stores/document-store.test.ts
+++ b/apps/desktop/src/__tests__/stores/document-store.test.ts
@@ -123,7 +123,7 @@ describe("useDocumentStore", () => {
 
     it("skips Python cache directories and bytecode files during open", async () => {
       vi.mocked(invoke).mockResolvedValue(undefined as never);
-      vi.mocked(readDir).mockImplementation(async (dir: string) => {
+      vi.mocked(readDir).mockImplementation(async (dir: string | URL) => {
         if (dir === "/project") {
           return [
             { name: "__pycache__", isDirectory: true },
@@ -136,7 +136,7 @@ describe("useDocumentStore", () => {
         throw new Error(`Unexpected readDir path: ${dir}`);
       });
       vi.mocked(stat).mockResolvedValue({ size: 32 } as any);
-      vi.mocked(readTextFile).mockImplementation(async (path: string) => {
+      vi.mocked(readTextFile).mockImplementation(async (path: string | URL) => {
         if (path === "/project/main.tex") {
           return "\\documentclass{article}";
         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@claude-prism/root",
   "description": "Open-Source AI LaTeX writing workspace",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/delibae/claude-prism"


### PR DESCRIPTION
## Summary
- Bump all version references from 1.1.6 → 1.1.7
- Fix TypeScript errors in test mocks caused by tauri 2.11 API signature change (`string` → `string | URL`)

## Test plan
- [x] `pnpm run lint` — passed
- [x] `pnpm run build` — passed
- [x] `pnpm run test` — 155/155 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)