### PR TITLE
fix: bump Linux vcpkg cache for tectonic 0.16

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -464,7 +464,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/vcpkg/installed
-          key: vcpkg-linux-x64-v1
+          key: vcpkg-linux-x64-v2
 
       - name: Install Linux dependencies (vcpkg)
         if: steps.vcpkg-cache.outputs.cache-hit != 'true'
@@ -482,7 +482,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ~/vcpkg/installed
-          key: vcpkg-linux-x64-v1
+          key: vcpkg-linux-x64-v2
 
       - uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
## Summary
- Bump Linux vcpkg cache key `v1` → `v2` to force fresh rebuild
- Needed after tectonic 0.15 → 0.16 upgrade (PR #157) which caused `gr_label_destroy` linker error on Linux CI

If this doesn't resolve it, we'll need to switch Linux to a static vcpkg triplet.

## Test plan
- [x] Trigger Build Desktop workflow and verify Linux job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)