### PR TITLE
fix: set VCPKGRS_TRIPLET for Linux static vcpkg build

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -516,6 +516,7 @@ jobs:
           ZOTERO_CONSUMER_KEY: ${{ secrets.ZOTERO_CONSUMER_KEY }}
           ZOTERO_CONSUMER_SECRET: ${{ secrets.ZOTERO_CONSUMER_SECRET }}
           TECTONIC_DEP_BACKEND: vcpkg
+          VCPKGRS_TRIPLET: x64-linux-static
           CXXFLAGS: "-std=c++17"
           CFLAGS: ""
         run: pnpm --filter @claude-prism/desktop tauri build --target x86_64-unknown-linux-gnu


### PR DESCRIPTION
## Summary
- Set `VCPKGRS_TRIPLET=x64-linux-static` in Linux build env
- Fixes `libpng is not installed for vcpkg triplet x64-linux` error — packages are installed under `x64-linux-static` but tectonic looks for `x64-linux` by default

## Test plan
- [ ] Build Desktop workflow Linux job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)