### PR TITLE
fix: add system libgraphite2-dev for Linux build

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -447,34 +447,25 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf \
-            autoconf autoconf-archive automake libtool pkg-config
+            autoconf autoconf-archive automake libtool pkg-config \
+            libgraphite2-dev
 
       # Static linking via vcpkg — avoids runtime dependency on system ICU/harfbuzz.
       # Without this, the binary links against the build host's libicuuc.so.70
       # (Ubuntu 22.04) and fails on distros shipping newer ICU (e.g. Ubuntu 25.10
       # with libicuuc.so.76). Mirrors the macOS approach (commit 9566956).
-      # Uses a custom static triplet because x64-linux defaults to dynamic libs,
-      # which causes hidden symbol errors with graphite2 (gr_label_destroy).
       - name: Setup vcpkg
         run: |
           git clone --depth 1 https://github.com/microsoft/vcpkg $HOME/vcpkg
           $HOME/vcpkg/bootstrap-vcpkg.sh
           echo "VCPKG_ROOT=$HOME/vcpkg" >> $GITHUB_ENV
 
-          # Create a static triplet for Linux
-          cat > $HOME/vcpkg/triplets/x64-linux-static.cmake <<'TRIPLET'
-          set(VCPKG_TARGET_ARCHITECTURE x64)
-          set(VCPKG_CRT_LINKAGE dynamic)
-          set(VCPKG_LIBRARY_LINKAGE static)
-          set(VCPKG_CMAKE_SYSTEM_NAME Linux)
-          TRIPLET
-
       - name: Restore vcpkg cache
         id: vcpkg-cache
         uses: actions/cache/restore@v4
         with:
           path: ~/vcpkg/installed
-          key: vcpkg-linux-x64-static-v1
+          key: vcpkg-linux-x64-v3
 
       - name: Install Linux dependencies (vcpkg)
         if: steps.vcpkg-cache.outputs.cache-hit != 'true'
@@ -482,17 +473,17 @@ jobs:
           VCPKG_BINARY_SOURCES: "clear"
         run: |
           $HOME/vcpkg/vcpkg install \
-            "harfbuzz[graphite2]:x64-linux-static" \
-            fontconfig:x64-linux-static \
-            freetype:x64-linux-static \
-            icu:x64-linux-static
+            "harfbuzz[graphite2]:x64-linux" \
+            fontconfig:x64-linux \
+            freetype:x64-linux \
+            icu:x64-linux
 
       - name: Save vcpkg cache
         if: steps.vcpkg-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: ~/vcpkg/installed
-          key: vcpkg-linux-x64-static-v1
+          key: vcpkg-linux-x64-v3
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -516,7 +507,6 @@ jobs:
           ZOTERO_CONSUMER_KEY: ${{ secrets.ZOTERO_CONSUMER_KEY }}
           ZOTERO_CONSUMER_SECRET: ${{ secrets.ZOTERO_CONSUMER_SECRET }}
           TECTONIC_DEP_BACKEND: vcpkg
-          VCPKGRS_TRIPLET: x64-linux-static
           CXXFLAGS: "-std=c++17"
           CFLAGS: ""
         run: pnpm --filter @claude-prism/desktop tauri build --target x86_64-unknown-linux-gnu


### PR DESCRIPTION
## Summary
- Revert custom x64-linux-static triplet back to x64-linux (with fresh cache key v3)
- Install `libgraphite2-dev` via apt to provide `gr_label_destroy` symbol
- vcpkg's graphite2 marks this symbol as hidden; system package exports it

## Test plan
- [ ] Build Desktop workflow Linux job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)