### PR TITLE
fix: restore Linux vcpkg cache key to v1

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -465,7 +465,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/vcpkg/installed
-          key: vcpkg-linux-x64-v3
+          key: vcpkg-linux-x64-v1
 
       - name: Install Linux dependencies (vcpkg)
         if: steps.vcpkg-cache.outputs.cache-hit != 'true'
@@ -483,7 +483,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ~/vcpkg/installed
-          key: vcpkg-linux-x64-v3
+          key: vcpkg-linux-x64-v1
 
       - uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
Fresh vcpkg graphite2 builds mark symbols as hidden. Restore old working cache.