### PR TITLE
fix: use temp file instead of process substitution for objcopy

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -509,21 +509,25 @@ jobs:
           TECTONIC_DEP_BACKEND: vcpkg
           CXXFLAGS: "-std=c++17"
           CFLAGS: ""
+        shell: bash
         run: |
           # Fix vcpkg graphite2: globalize hidden symbols so tectonic can link them
           # objcopy doesn't work directly on .a archives — must extract, patch, repack
           VCPKG_GR2="$HOME/vcpkg/installed/x64-linux/lib/libgraphite2.a"
           if [ -f "$VCPKG_GR2" ]; then
-            TMPDIR=$(mktemp -d)
-            cd "$TMPDIR"
+            WORK=$(mktemp -d)
+            cd "$WORK"
             ar x "$VCPKG_GR2"
-            for obj in *.o *.obj 2>/dev/null; do
+            for obj in *.o; do
               [ -f "$obj" ] || continue
-              objcopy --globalize-symbols=<(nm "$obj" 2>/dev/null | grep ' t gr_\| d gr_' | awk '{print $3}') "$obj" 2>/dev/null || true
+              nm "$obj" 2>/dev/null | grep ' t gr_\| d gr_' | awk '{print $3}' > syms.txt
+              if [ -s syms.txt ]; then
+                objcopy --globalize-symbols=syms.txt "$obj"
+              fi
             done
-            ar rcs "$VCPKG_GR2" *.o *.obj 2>/dev/null || ar rcs "$VCPKG_GR2" *.o
+            ar rcs "$VCPKG_GR2" *.o
             cd /home/runner/work/claude-prism/claude-prism
-            rm -rf "$TMPDIR"
+            rm -rf "$WORK"
           fi
           pnpm --filter @claude-prism/desktop tauri build --target x86_64-unknown-linux-gnu
 


### PR DESCRIPTION
Process substitution syntax error in CI. Write symbols to file instead.