### PR TITLE
fix: handle grep no-match exit code in objcopy script

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -520,7 +520,7 @@ jobs:
             ar x "$VCPKG_GR2"
             for obj in *.o; do
               [ -f "$obj" ] || continue
-              nm "$obj" 2>/dev/null | grep ' t gr_\| d gr_' | awk '{print $3}' > syms.txt
+              nm "$obj" 2>/dev/null | { grep ' t gr_\| d gr_' || true; } | awk '{print $3}' > syms.txt
               if [ -s syms.txt ]; then
                 objcopy --globalize-symbols=syms.txt "$obj"
               fi


### PR DESCRIPTION
grep exit 1 on no match aborts under set -e.