### PR TITLE
fix: add --undefined-version flag for ld.bfd compat

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -513,7 +513,7 @@ jobs:
           # vcpkg builds graphite2 with STV_HIDDEN on gr_* symbols.
           # rust-lld treats hidden symbol refs as hard errors; ld.bfd does not.
           # Switch to ld.bfd for linking.
-          export RUSTFLAGS="-C linker=gcc -C link-arg=-fuse-ld=bfd"
+          export RUSTFLAGS="-C linker=gcc -C link-arg=-fuse-ld=bfd -C link-arg=-Wl,--undefined-version"
           pnpm --filter @claude-prism/desktop tauri build --target x86_64-unknown-linux-gnu
 
       - name: Collect updater artifacts


### PR DESCRIPTION
ld.bfd needs --undefined-version for Rust symbols.map compatibility.