### PR TITLE
fix: use mold linker for Linux build

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -448,7 +448,7 @@ jobs:
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf \
             autoconf autoconf-archive automake libtool pkg-config \
-            libgraphite2-dev
+            libgraphite2-dev mold
 
       # Static linking via vcpkg — avoids runtime dependency on system ICU/harfbuzz.
       # Without this, the binary links against the build host's libicuuc.so.70
@@ -513,7 +513,8 @@ jobs:
           # vcpkg builds graphite2 with STV_HIDDEN on gr_* symbols.
           # rust-lld treats hidden symbol refs as hard errors; ld.bfd does not.
           # Switch to ld.bfd for linking.
-          export RUSTFLAGS="-C linker=gcc -C link-arg=-fuse-ld=bfd -C link-arg=-Wl,--undefined-version"
+          # Use ld.mold which handles both hidden symbols and version scripts correctly
+          export RUSTFLAGS="-C linker=gcc -C link-arg=-fuse-ld=mold"
           pnpm --filter @claude-prism/desktop tauri build --target x86_64-unknown-linux-gnu
 
       - name: Collect updater artifacts


### PR DESCRIPTION
mold handles both hidden graphite2 symbols and Rust version scripts correctly, unlike lld (fails on hidden) or ld.bfd (fails on version scripts).