### PR TITLE
fix: prepend vcpkg lib path for mold ICU resolution

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -514,7 +514,9 @@ jobs:
           # rust-lld treats hidden symbol refs as hard errors; ld.bfd does not.
           # Switch to ld.bfd for linking.
           # Use ld.mold which handles both hidden symbols and version scripts correctly
-          export RUSTFLAGS="-C linker=gcc -C link-arg=-fuse-ld=mold"
+          # Prepend vcpkg lib path so mold finds vcpkg's ICU (with correct version suffix) first
+          export LIBRARY_PATH="$HOME/vcpkg/installed/x64-linux/lib:${LIBRARY_PATH:-}"
+          export RUSTFLAGS="-C linker=gcc -C link-arg=-fuse-ld=mold -C link-arg=-L$HOME/vcpkg/installed/x64-linux/lib"
           pnpm --filter @claude-prism/desktop tauri build --target x86_64-unknown-linux-gnu
 
       - name: Collect updater artifacts


### PR DESCRIPTION
mold finds system ICU 70 instead of vcpkg ICU 78. Add explicit lib path.