### PR TITLE
fix: remove system ICU .so to force vcpkg ICU 78 on Linux

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -514,9 +514,9 @@ jobs:
           # rust-lld treats hidden symbol refs as hard errors; ld.bfd does not.
           # Switch to ld.bfd for linking.
           # Use ld.mold which handles both hidden symbols and version scripts correctly
-          # Prepend vcpkg lib path so mold finds vcpkg's ICU (with correct version suffix) first
-          export LIBRARY_PATH="$HOME/vcpkg/installed/x64-linux/lib:${LIBRARY_PATH:-}"
-          export RUSTFLAGS="-C linker=gcc -C link-arg=-fuse-ld=mold -C link-arg=-L$HOME/vcpkg/installed/x64-linux/lib"
+          # Remove system ICU shared libs to force linking against vcpkg's static ICU
+          sudo rm -f /usr/lib/x86_64-linux-gnu/libicu{uc,i18n,io,tu,data}.so* 2>/dev/null || true
+          export RUSTFLAGS="-C linker=gcc -C link-arg=-fuse-ld=mold"
           pnpm --filter @claude-prism/desktop tauri build --target x86_64-unknown-linux-gnu
 
       - name: Collect updater artifacts


### PR DESCRIPTION
System ICU 70 .so takes precedence over vcpkg ICU 78. Remove system .so files.