### PR TITLE
fix: disable rust-lld on Linux (graphite2 hidden symbol compat)

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -508,6 +508,9 @@ jobs:
           TECTONIC_DEP_BACKEND: vcpkg
           CXXFLAGS: "-std=c++17"
           CFLAGS: ""
+          # Rust 1.95+ enables rust-lld by default on Linux, which errors on
+          # vcpkg graphite2's hidden symbols. Disable it to use cc/ld.bfd as before.
+          RUSTFLAGS: "-Clinker-features=-lld"
         run: pnpm --filter @claude-prism/desktop tauri build --target x86_64-unknown-linux-gnu
 
       - name: Collect updater artifacts


### PR DESCRIPTION
## Root cause found

v1.1.6 built with Rust 1.94.1 (cc/ld.bfd default). Current CI uses
Rust 1.96.0 which enables rust-lld by default on Linux. rust-lld
treats STV_HIDDEN symbols as hard errors, while ld.bfd does not.

vcpkg's graphite2 has hidden visibility on gr_* symbols → link failure.

## Fix

Add `RUSTFLAGS="-Clinker-features=-lld"` to Linux build step to
disable rust-lld and use cc/ld.bfd as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)