### PR TITLE
fix: pin Rust 1.94.1 on Linux build

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -484,7 +484,10 @@ jobs:
           path: ~/vcpkg/installed
           key: vcpkg-linux-x64-v1
 
-      - uses: dtolnay/rust-toolchain@stable
+      # Pin Rust to 1.94.1 on Linux — Rust 1.95+ enables rust-lld which errors
+      # on vcpkg graphite2's hidden symbols, and generates version scripts
+      # incompatible with ld.bfd.
+      - uses: dtolnay/rust-toolchain@1.94.1
         with:
           targets: x86_64-unknown-linux-gnu
 
@@ -508,9 +511,6 @@ jobs:
           TECTONIC_DEP_BACKEND: vcpkg
           CXXFLAGS: "-std=c++17"
           CFLAGS: ""
-          # Rust 1.95+ enables rust-lld by default on Linux, which errors on
-          # vcpkg graphite2's hidden symbols. Disable it to use cc/ld.bfd as before.
-          RUSTFLAGS: "-Clinker-features=-lld"
         run: pnpm --filter @claude-prism/desktop tauri build --target x86_64-unknown-linux-gnu
 
       - name: Collect updater artifacts


### PR DESCRIPTION
Rust 1.95+ breaks Linux build with vcpkg. Pin to 1.94.1 to match v1.1.6.