### PR TITLE
fix: separate Rust cache for Linux 1.94.1 build

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -494,6 +494,7 @@ jobs:
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: apps/desktop/src-tauri -> target
+          prefix-key: rust-1941
 
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Stale rust-lld from 1.96 cache was polluting 1.94.1 builds.