### PR TITLE
fix: remove rust-lld wrapper to use system ld on Linux

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -512,7 +512,11 @@ jobs:
           TECTONIC_DEP_BACKEND: vcpkg
           CXXFLAGS: "-std=c++17"
           CFLAGS: ""
-        run: pnpm --filter @claude-prism/desktop tauri build --target x86_64-unknown-linux-gnu
+        run: |
+          # Remove rust-lld wrapper so cc uses system ld.bfd instead.
+          # rust-lld errors on vcpkg graphite2's hidden symbols.
+          rm -rf "$(rustc --print sysroot)/lib/rustlib/x86_64-unknown-linux-gnu/bin/gcc-ld"
+          pnpm --filter @claude-prism/desktop tauri build --target x86_64-unknown-linux-gnu
 
       - name: Collect updater artifacts
         id: collect


### PR DESCRIPTION
Delete gcc-ld directory from sysroot before build.