### PR TITLE
fix: vcpkg overlay port for graphite2 with default symbol visibility

### DIFF
--- a/.github/vcpkg-overlays/graphite2/disable-tests.patch
+++ b/.github/vcpkg-overlays/graphite2/disable-tests.patch
@@ -1,0 +1,48 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 496712d..3df05c7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -82,10 +82,12 @@ if (BUILD_SHARED_LIBS)
+ endif()
+ 
+ add_subdirectory(src)
+-add_subdirectory(tests)
+-add_subdirectory(doc)
+-if (NOT GRAPHITE2_NFILEFACE)
+-    add_subdirectory(gr2fonttest)
++if(NOT DISABLE_TESTS)
++    add_subdirectory(tests)
++    add_subdirectory(doc)
++    if (NOT GRAPHITE2_NFILEFACE)
++        add_subdirectory(gr2fonttest)
++    endif()
+ endif()
+ 
+ set(version 3.0.1)
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index b6ac26b..851a97f 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -127,9 +127,9 @@ if  (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+         endif ()
+     endif()
+     include(Graphite)
+-    if (BUILD_SHARED_LIBS)
++    if (NOT DISABLE_TESTS)
+         nolib_test(stdc++ $<TARGET_SONAME_FILE:graphite2>)
+-    endif ()
++    endif()
+     set(CMAKE_CXX_IMPLICIT_LINK_LIBRARIES "")
+     CREATE_LIBTOOL_FILE(graphite2 "/lib${LIB_SUFFIX}")
+ endif()
+@@ -144,7 +144,9 @@ if  (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+     endif()
+     target_link_libraries(graphite2 c)
+     include(Graphite)
+-    nolib_test(stdc++ $<TARGET_SONAME_FILE:graphite2>)
++    if (NOT DISABLE_TESTS)
++        nolib_test(stdc++ $<TARGET_SONAME_FILE:graphite2>)
++    endif()
+     set(CMAKE_CXX_IMPLICIT_LINK_LIBRARIES "")
+     CREATE_LIBTOOL_FILE(graphite2 "/lib${LIB_SUFFIX}")
+ endif()

--- a/.github/vcpkg-overlays/graphite2/portfile.cmake
+++ b/.github/vcpkg-overlays/graphite2/portfile.cmake
@@ -1,0 +1,36 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO silnrsi/graphite
+    REF 92f59dcc52f73ce747f1cdc831579ed2546884aa # 1.3.14
+    SHA512 011855576124b2f9ae9d7d3a0dfc5489794cf82b81bebc02c11c9cca350feb9fbb411844558811dff1ebbacac58a24a7cf56a374fc2c27e97a5fb4795a01486e
+    HEAD_REF master
+    PATCHES disable-tests.patch
+)
+
+# Force default symbol visibility so gr_* symbols are exported in static libs.
+# Without this, static builds use -fvisibility=hidden and rust-lld/mold
+# cannot resolve the hidden symbols at link time.
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DDISABLE_TESTS=ON
+        -DCMAKE_C_VISIBILITY_PRESET=default
+        -DCMAKE_CXX_VISIBILITY_PRESET=default
+        -DCMAKE_C_FLAGS=-fvisibility=default
+        -DCMAKE_CXX_FLAGS=-fvisibility=default
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup()
+vcpkg_fixup_pkgconfig()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/graphite2/Types.h" "defined GRAPHITE2_STATIC" "1")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE "${CURRENT_PACKAGES_DIR}/lib/libgraphite2.la" "${CURRENT_PACKAGES_DIR}/debug/lib/libgraphite2.la")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING" "${SOURCE_PATH}/LICENSE")

--- a/.github/vcpkg-overlays/graphite2/vcpkg.json
+++ b/.github/vcpkg-overlays/graphite2/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "graphite2",
+  "version": "1.3.14",
+  "port-version": 100,
+  "description": "Graphite2 with default symbol visibility (overlay port)",
+  "homepage": "https://github.com/silnrsi/graphite",
+  "dependencies": [
+    { "name": "vcpkg-cmake", "host": true },
+    { "name": "vcpkg-cmake-config", "host": true }
+  ]
+}

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -447,9 +447,42 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf \
-            autoconf autoconf-archive automake libtool pkg-config \
-            libharfbuzz-dev libgraphite2-dev libicu-dev libfreetype-dev \
-            libfontconfig-dev libpng-dev
+            autoconf autoconf-archive automake libtool pkg-config
+
+      # Static linking via vcpkg with overlay port for graphite2.
+      # The overlay rebuilds graphite2 with -fvisibility=default so symbols
+      # are exported properly in static libs (fixes rust-lld hidden symbol errors).
+      - name: Setup vcpkg
+        run: |
+          git clone --depth 1 https://github.com/microsoft/vcpkg $HOME/vcpkg
+          $HOME/vcpkg/bootstrap-vcpkg.sh
+          echo "VCPKG_ROOT=$HOME/vcpkg" >> $GITHUB_ENV
+
+      - name: Restore vcpkg cache
+        id: vcpkg-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/vcpkg/installed
+          key: vcpkg-linux-x64-overlay-v1
+
+      - name: Install Linux dependencies (vcpkg)
+        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
+        env:
+          VCPKG_BINARY_SOURCES: "clear"
+        run: |
+          $HOME/vcpkg/vcpkg install \
+            --overlay-ports=$GITHUB_WORKSPACE/.github/vcpkg-overlays \
+            "harfbuzz[graphite2]:x64-linux" \
+            fontconfig:x64-linux \
+            freetype:x64-linux \
+            icu:x64-linux
+
+      - name: Save vcpkg cache
+        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/vcpkg/installed
+          key: vcpkg-linux-x64-overlay-v1
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -472,7 +505,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ZOTERO_CONSUMER_KEY: ${{ secrets.ZOTERO_CONSUMER_KEY }}
           ZOTERO_CONSUMER_SECRET: ${{ secrets.ZOTERO_CONSUMER_SECRET }}
-          TECTONIC_DEP_BACKEND: pkg-config
+          TECTONIC_DEP_BACKEND: vcpkg
           CXXFLAGS: "-std=c++17"
           CFLAGS: ""
         run: pnpm --filter @claude-prism/desktop tauri build --target x86_64-unknown-linux-gnu


### PR DESCRIPTION
## Summary
Add vcpkg overlay port that rebuilds graphite2 with `-fvisibility=default`.

This is the proper fix for the Linux build failure — vcpkg's graphite2
uses hidden visibility, which rust-lld (default since Rust 1.95) rejects.

- No linker hacks (no mold, no ld.bfd wrapper, no RUSTFLAGS)
- No system package fallback (keeps static linking for portable binaries)
- Ubuntu 24.04, Rust stable, default linker

🤖 Generated with [Claude Code](https://claude.com/claude-code)