### PR TITLE
fix: bump vcpkg cache for graphite2 overlay v2

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -463,7 +463,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/vcpkg/installed
-          key: vcpkg-linux-x64-overlay-v1
+          key: vcpkg-linux-x64-overlay-v2
 
       - name: Install Linux dependencies (vcpkg)
         if: steps.vcpkg-cache.outputs.cache-hit != 'true'
@@ -482,7 +482,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ~/vcpkg/installed
-          key: vcpkg-linux-x64-overlay-v1
+          key: vcpkg-linux-x64-overlay-v2
 
       - uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
Need fresh rebuild with corrected overlay.