### PR TITLE
fix: hide compiled build artifacts from project file tree

### DIFF
--- a/apps/desktop/src/__tests__/lib/tauri-fs.test.ts
+++ b/apps/desktop/src/__tests__/lib/tauri-fs.test.ts
@@ -23,9 +23,12 @@ describe("tauri fs helpers", () => {
       expect(getProjectFileType("script.py")).toBe("other");
     });
 
-    it("ignores LaTeX build artifacts", () => {
+    it("ignores LaTeX and compiled build artifacts", () => {
       expect(getProjectFileType("main.aux")).toBeNull();
       expect(getProjectFileType("main.synctex.gz")).toBeNull();
+      expect(getProjectFileType("module.pyc")).toBeNull();
+      expect(getProjectFileType("native.pyd")).toBeNull();
+      expect(getProjectFileType("libnative.so")).toBeNull();
     });
 
     it("keeps imported files with arbitrary extensions visible", () => {
@@ -33,8 +36,6 @@ describe("tauri fs helpers", () => {
       expect(getProjectFileType("paper.docx")).toBe("other");
       expect(getProjectFileType("data.xlsx")).toBe("other");
       expect(getProjectFileType("movie.mp4")).toBe("other");
-      expect(getProjectFileType("module.pyc")).toBe("other");
-      expect(getProjectFileType("native.pyd")).toBe("other");
     });
   });
 
@@ -90,7 +91,6 @@ describe("tauri fs helpers", () => {
 
     it("keeps arbitrary file formats visible as other files", async () => {
       vi.mocked(readDir).mockResolvedValue([
-        { name: "module.pyc", isDirectory: false },
         { name: "worker.py", isDirectory: false },
         { name: "notes.txt", isDirectory: false },
       ] as any);
@@ -99,11 +99,10 @@ describe("tauri fs helpers", () => {
       const result = await scanProjectFolder("/project");
 
       expect(result.files.map((file) => file.relativePath)).toEqual([
-        "module.pyc",
         "worker.py",
         "notes.txt",
       ]);
-      expect(stat).toHaveBeenCalledTimes(3);
+      expect(stat).toHaveBeenCalledTimes(2);
       expect(result.files.every((file) => file.type === "other")).toBe(true);
     });
   });

--- a/apps/desktop/src/lib/tauri/fs.ts
+++ b/apps/desktop/src/lib/tauri/fs.ts
@@ -81,6 +81,15 @@ const IGNORED_EXTENSIONS = new Set([
   ".vrb",
   ".run.xml",
   ".bcf",
+  // Compiled build artifacts (never user reference material)
+  ".pyc",
+  ".pyo",
+  ".pyd",
+  ".o",
+  ".obj",
+  ".so",
+  ".dylib",
+  ".dll",
 ]);
 
 export function shouldSkipProjectDirectory(name: string): boolean {


### PR DESCRIPTION
PR #154 intentionally made user-imported reference files (.docx, .zip, media, …) visible in the file tree, but the removed ignore list also covered compiled build artifacts — so `.pyc`, `.so`, etc. started showing up, contradicting both the `__pycache__` directory skip that #154 kept and the PR #129 regression test (which has been failing on main since).

- Restore ignore rules for `.pyc .pyo .pyd .o .obj .so .dylib .dll` (reference-file visibility from #154 is unchanged)
- Update the #154 tests that asserted `.pyc`/`.pyd` visibility; the #129 test passes again
- Full suite: 200/200 green, biome + tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)