### PR TITLE
fix(latex): harden tectonic compile against warnings, subdirs, and mi…

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -53,7 +53,7 @@ ClaudePrism は**ローカルファースト**の代替ツールです — フ�
 
 | | OpenAI Prism | ClaudePrism |
 |---|:---:|:---:|
-| AI モデル | GPT-5.2 | **Claude Opus / Sonnet / Haiku** |
+| AI モデル | GPT-5.2 | **Claude Fable / Opus / Sonnet / Haiku** |
 | 実行環境 | ブラウザ（クラウド） | **ネイティブデスクトップ（Tauri 2 + Rust）** |
 | LaTeX | クラウドコンパイル | **Tectonic 内蔵（オフライン対応）** |
 | Python 環境 | — | **uv + venv 内蔵 ── ワンクリックで科学計算向け Python 環境を構築** |

--- a/README.ko.md
+++ b/README.ko.md
@@ -53,7 +53,7 @@ ClaudePrism은 **로컬 우선** 대안입니다 — 파일은 로컬 디스크�
 
 | | OpenAI Prism | ClaudePrism |
 |---|:---:|:---:|
-| AI 모델 | GPT-5.2 | **Claude Opus / Sonnet / Haiku** |
+| AI 모델 | GPT-5.2 | **Claude Fable / Opus / Sonnet / Haiku** |
 | 실행 환경 | 브라우저 (클라우드) | **네이티브 데스크톱 (Tauri 2 + Rust)** |
 | LaTeX | 클라우드 컴파일 | **Tectonic (내장, 오프라인)** |
 | Python 환경 | — | **내장 uv + venv — 원클릭 과학 Python 환경** |

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ ClaudePrism is a **local-first** alternative — your files are stored on your d
 
 | | OpenAI Prism | ClaudePrism |
 |---|:---:|:---:|
-| AI Model | GPT-5.2 | **Claude Opus / Sonnet / Haiku** |
+| AI Model | GPT-5.2 | **Claude Fable / Opus / Sonnet / Haiku** |
 | Runtime | Browser (cloud) | **Native desktop (Tauri 2 + Rust)** |
 | LaTeX | Cloud compilation | **Tectonic (embedded, offline)** |
 | Python Environment | — | **Built-in uv + venv — one-click scientific Python setup** |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -39,7 +39,7 @@ ClaudePrism 是**本地优先**的替代方案 — 文件存储在本地磁盘�
 
 | | OpenAI Prism | ClaudePrism |
 |---|:---:|:---:|
-| AI 模型 | GPT-5.2 | **Claude Opus / Sonnet / Haiku** |
+| AI 模型 | GPT-5.2 | **Claude Fable / Opus / Sonnet / Haiku** |
 | 运行环境 | 浏览器（云端） | **原生桌面应用（Tauri 2 + Rust）** |
 | LaTeX | 云端编译 | **Tectonic（内嵌，离线）** |
 | Python 环境 | — | **内置 uv + venv — 一键科学 Python 环境** |

--- a/apps/desktop/src-tauri/src/claude.rs
+++ b/apps/desktop/src-tauri/src/claude.rs
@@ -634,7 +634,10 @@ fn is_claude_model_selector(value: &str) -> bool {
         return true;
     }
 
-    matches!(model.as_str(), "sonnet" | "opus" | "haiku" | "opusplan")
+    matches!(
+        model.as_str(),
+        "fable" | "sonnet" | "opus" | "haiku" | "opusplan"
+    )
 }
 
 fn normalize_provider_model_override(value: Option<&str>) -> Result<Option<String>, String> {
@@ -4339,6 +4342,14 @@ mod tests {
         );
         assert_eq!(
             normalize_provider_model_override(Some("opusplan")).unwrap(),
+            None
+        );
+        assert_eq!(
+            normalize_provider_model_override(Some("fable")).unwrap(),
+            None
+        );
+        assert_eq!(
+            normalize_provider_model_override(Some("claude-fable-5-1")).unwrap(),
             None
         );
         assert_eq!(

--- a/apps/desktop/src-tauri/src/latex.rs
+++ b/apps/desktop/src-tauri/src/latex.rs
@@ -361,6 +361,7 @@ pub(crate) fn compile_with_tectonic(work_dir: &Path, main_file: &str) -> Result<
     use tectonic::config::PersistentConfig;
     use tectonic::driver::{OutputFormat, PassSetting, ProcessingSessionBuilder};
     use tectonic::status::NoopStatusBackend;
+    use tectonic::unstable_opts::UnstableOptions;
 
     let mut status = NoopStatusBackend {};
 
@@ -378,11 +379,19 @@ pub(crate) fn compile_with_tectonic(work_dir: &Path, main_file: &str) -> Result<
         .format_cache_path()
         .map_err(|e| format!("Failed to get format cache path: {}", e))?;
 
+    // Use just the filename (not subdirectory-relative path) for tex_input_name
+    // so that xdvipdfmx looks for "main.xdv" rather than "subdir/main.xdv".
+    let tex_name = Path::new(main_file)
+        .file_name()
+        .unwrap_or(std::ffi::OsStr::new(main_file))
+        .to_string_lossy()
+        .into_owned();
+
     let mut builder = ProcessingSessionBuilder::default();
     builder
         .bundle(bundle)
         .primary_input_path(work_dir.join(main_file))
-        .tex_input_name(main_file)
+        .tex_input_name(&tex_name)
         .filesystem_root(work_dir)
         .output_dir(work_dir)
         .format_name("latex")
@@ -391,13 +400,63 @@ pub(crate) fn compile_with_tectonic(work_dir: &Path, main_file: &str) -> Result<
         .pass(PassSetting::Default)
         .synctex(true)
         .keep_intermediates(true)
-        .keep_logs(true);
+        .keep_logs(true)
+        .unstables(UnstableOptions {
+            continue_on_errors: true,
+            ..Default::default()
+        });
 
     let mut session = builder
         .create(&mut status)
         .map_err(|e| format!("Failed to create tectonic session: {}", e))?;
 
-    session.run(&mut status).map_err(|e| format!("{}", e))?;
+    let run_result = session.run(&mut status);
+
+    let main_stem = Path::new(main_file)
+        .file_stem()
+        .unwrap_or_default()
+        .to_string_lossy();
+    let pdf_path = work_dir.join(format!("{}.pdf", main_stem));
+    let xdv_path = work_dir.join(format!("{}.xdv", main_stem));
+
+    // Tectonic returns errors for mere warnings (font substitutions, class
+    // info messages, etc.), which aborts the pipeline before the XDV→PDF
+    // conversion step.  If the PDF was produced despite the error, succeed.
+    if pdf_path.exists() {
+        return Ok(());
+    }
+
+    // If no PDF but the XDV exists, the TeX passes succeeded but the
+    // XDV→PDF step was skipped due to warnings.  Attempt manual conversion
+    // via xdvipdfmx (same fallback the TeXLive backend uses).
+    if xdv_path.exists() {
+        eprintln!("[tectonic] .xdv exists but no .pdf — running xdvipdfmx manually");
+        if let Ok(xdvipdfmx) = find_texlive_binary("xdvipdfmx") {
+            let mut cmd = std::process::Command::new(&xdvipdfmx);
+            cmd.args(["-o", &pdf_path.to_string_lossy()])
+                .arg(&xdv_path)
+                .current_dir(work_dir)
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped());
+            #[cfg(target_os = "windows")]
+            cmd.creation_flags(CREATE_NO_WINDOW);
+            if let Ok(output) = cmd.output() {
+                if output.status.success() {
+                    eprintln!("[tectonic] xdvipdfmx fallback succeeded");
+                    return Ok(());
+                }
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                if !stderr.trim().is_empty() {
+                    eprintln!("[tectonic] xdvipdfmx stderr: {}", stderr.trim());
+                }
+            }
+        } else {
+            eprintln!("[tectonic] xdvipdfmx not found on PATH — cannot convert .xdv to .pdf");
+        }
+    }
+
+    // No PDF and no successful fallback — propagate the original error.
+    run_result.map_err(|e| format!("{}", e))?;
 
     Ok(())
 }
@@ -419,16 +478,20 @@ fn compile_with_tectonic_subprocess(work_dir: &Path, main_file: &str) -> Result<
     cmd.args(["--tectonic-compile", &work_dir.to_string_lossy(), main_file])
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
+
     #[cfg(target_os = "windows")]
     cmd.creation_flags(CREATE_NO_WINDOW);
     let output = cmd
         .output()
         .map_err(|e| format!("Failed to spawn tectonic subprocess: {}", e))?;
 
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !stderr.trim().is_empty() {
+        eprintln!("[tectonic-subprocess] stderr: {}", stderr.trim());
+    }
     if output.status.success() {
         Ok(())
     } else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
         Err(stderr.trim().to_string())
     }
 }
@@ -827,6 +890,23 @@ pub async fn compile_latex(
 
     let t0 = std::time::Instant::now();
     let use_texlive = use_texlive.unwrap_or(false);
+
+    // On Windows, ensure fontconfig can find its config so that xdvipdfmx
+    // (used by both Tectonic and TeXLive/xelatex) can locate and embed fonts.
+    #[cfg(target_os = "windows")]
+    {
+        if std::env::var("FONTCONFIG_PATH").is_err() {
+            let vcpkg_root = std::env::var("VCPKG_ROOT").unwrap_or_else(|_| "C:\\vcpkg".into());
+            let fc_path = PathBuf::from(&vcpkg_root)
+                .join("installed")
+                .join("x64-windows")
+                .join("etc")
+                .join("fonts");
+            if fc_path.exists() {
+                std::env::set_var("FONTCONFIG_PATH", &fc_path);
+            }
+        }
+    }
 
     let main_file_name = Path::new(&main_file)
         .file_stem()

--- a/apps/desktop/src/__tests__/lib/latex-diagnostics.test.ts
+++ b/apps/desktop/src/__tests__/lib/latex-diagnostics.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import type { ProjectFile } from "@/stores/document-store";
+import { filterProjectDiagnostics } from "@/lib/latex-diagnostics";
+
+function tex(relativePath: string, content: string): ProjectFile {
+  return {
+    id: relativePath,
+    name: relativePath.split("/").pop() ?? relativePath,
+    relativePath,
+    absolutePath: `/project/${relativePath}`,
+    type: "tex",
+    content,
+    isDirty: false,
+  };
+}
+
+const MISSING_DOC_ENV = {
+  message:
+    "Missing document environment. LaTeX documents should be enclosed in \\begin{document}...\\end{document}",
+};
+const files = [
+  tex(
+    "main.tex",
+    "\\documentclass{article}\n\\begin{document}\n\\label{sec:intro}\n\\input{sections/results}\n\\end{document}",
+  ),
+  tex(
+    "sections/results.tex",
+    "\\section{Results}\\label{sec:results} See \\ref{sec:intro} and \\ref{sec:nowhere}.",
+  ),
+];
+
+describe("filterProjectDiagnostics", () => {
+  it("drops the missing-document warning for included section files", () => {
+    expect(
+      filterProjectDiagnostics(
+        [MISSING_DOC_ENV],
+        "sections/results.tex",
+        files,
+      ),
+    ).toEqual([]);
+  });
+
+  it("keeps the missing-document warning for the root file", () => {
+    expect(
+      filterProjectDiagnostics([MISSING_DOC_ENV], "main.tex", files),
+    ).toEqual([MISSING_DOC_ENV]);
+  });
+
+  it("drops undefined-label warnings when the label lives in another file", () => {
+    const defined = { message: "Reference to undefined label: sec:intro" };
+    const missing = { message: "Reference to undefined label: sec:nowhere" };
+    expect(
+      filterProjectDiagnostics(
+        [defined, missing],
+        "sections/results.tex",
+        files,
+      ),
+    ).toEqual([missing]);
+  });
+
+  it("leaves unrelated diagnostics untouched", () => {
+    const other = { message: "Missing \\end{figure}" };
+    expect(
+      filterProjectDiagnostics([other], "sections/results.tex", files),
+    ).toEqual([other]);
+  });
+});

--- a/apps/desktop/src/__tests__/lib/tex-project.test.ts
+++ b/apps/desktop/src/__tests__/lib/tex-project.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest";
+import type { ProjectFile } from "@/stores/document-store";
+import {
+  collectProjectLabels,
+  findIncludingRoots,
+  normalizeTexPath,
+  resolveTexRoot,
+} from "@/lib/tex-project";
+
+function tex(relativePath: string, content: string): ProjectFile {
+  return {
+    id: relativePath,
+    name: relativePath.split("/").pop() ?? relativePath,
+    relativePath,
+    absolutePath: `/project/${relativePath}`,
+    type: "tex",
+    content,
+    isDirty: false,
+  };
+}
+
+const ROOT = "\\documentclass{article}\n\\begin{document}\n";
+
+describe("normalizeTexPath", () => {
+  it("collapses dot segments and backslashes", () => {
+    expect(normalizeTexPath("sections/../sections/./intro.tex")).toBe(
+      "sections/intro.tex",
+    );
+    expect(normalizeTexPath("sections\\intro.tex")).toBe("sections/intro.tex");
+    expect(normalizeTexPath("./main.tex")).toBe("main.tex");
+  });
+});
+
+describe("resolveTexRoot", () => {
+  it("resolves a section file to the root that \\input's it", () => {
+    const files = [
+      tex("paper.tex", `${ROOT}\\input{sections/intro}\n\\end{document}`),
+      tex("sections/intro.tex", "\\section{Intro}\nText.\n"),
+    ];
+    expect(resolveTexRoot("sections/intro.tex", files)).toBe("paper.tex");
+  });
+
+  it("prefers the root that actually includes the file over other roots", () => {
+    const files = [
+      tex("main.tex", `${ROOT}Standalone\n\\end{document}`),
+      tex(
+        "thesis.tex",
+        `${ROOT}\\include{chapters/ch1}\n\\input{sections/intro.tex}\n\\end{document}`,
+      ),
+      tex("chapters/ch1.tex", "\\chapter{One}"),
+      tex("sections/intro.tex", "\\section{Intro}"),
+    ];
+    expect(resolveTexRoot("chapters/ch1.tex", files)).toBe("thesis.tex");
+    expect(resolveTexRoot("sections/intro.tex", files)).toBe("thesis.tex");
+  });
+
+  it("follows transitive includes", () => {
+    const files = [
+      tex("main.tex", `${ROOT}\\input{sections/all}\n\\end{document}`),
+      tex("sections/all.tex", "\\input{sections/a}\n\\input{sections/b}\n"),
+      tex("sections/a.tex", "A"),
+      tex("sections/b.tex", "B"),
+    ];
+    expect(resolveTexRoot("sections/b.tex", files)).toBe("main.tex");
+  });
+
+  it("ignores commented-out includes", () => {
+    const files = [
+      tex("main.tex", `${ROOT}% \\input{sections/old}\n\\end{document}`),
+      tex("other.tex", `${ROOT}\\input{sections/old}\n\\end{document}`),
+      tex("sections/old.tex", "Old"),
+    ];
+    expect(resolveTexRoot("sections/old.tex", files)).toBe("other.tex");
+  });
+
+  it("resolves includes relative to the including file's directory", () => {
+    const files = [
+      tex("main.tex", `${ROOT}\\input{chapters/ch1}\n\\end{document}`),
+      tex("chapters/ch1.tex", "\\input{ch1-details}"),
+      tex("chapters/ch1-details.tex", "Details"),
+    ];
+    expect(resolveTexRoot("chapters/ch1-details.tex", files)).toBe("main.tex");
+  });
+
+  it("resolves \\import and \\subimport", () => {
+    const files = [
+      tex("main.tex", `${ROOT}\\import{sections/}{intro}\n\\end{document}`),
+      tex("sections/intro.tex", "\\subimport{sub/}{deep}"),
+      tex("sections/sub/deep.tex", "Deep"),
+    ];
+    expect(resolveTexRoot("sections/sub/deep.tex", files)).toBe("main.tex");
+  });
+
+  it("resolves a relative % !TEX root magic comment", () => {
+    const files = [
+      tex("main.tex", `${ROOT}\\end{document}`),
+      tex("sections/intro.tex", "% !TEX root = ../main.tex\nText"),
+    ];
+    expect(resolveTexRoot("sections/intro.tex", files)).toBe("main.tex");
+  });
+
+  it("returns the file itself when it has \\documentclass", () => {
+    const files = [
+      tex("main.tex", `${ROOT}\\input{fig}\n\\end{document}`),
+      tex("fig.tex", "\\documentclass{standalone}\n\\begin{document}x"),
+    ];
+    expect(resolveTexRoot("fig.tex", files)).toBe("fig.tex");
+  });
+
+  it("falls back to main.tex for a not-yet-included file", () => {
+    const files = [
+      tex("main.tex", `${ROOT}\\end{document}`),
+      tex("sections/new.tex", "New section"),
+    ];
+    expect(resolveTexRoot("sections/new.tex", files)).toBe("main.tex");
+  });
+
+  it("falls back to main.tex when the file's content is not loaded yet", () => {
+    const files = [
+      tex("main.tex", `${ROOT}\\end{document}`),
+      { ...tex("sections/lazy.tex", ""), content: undefined },
+    ];
+    expect(resolveTexRoot("sections/lazy.tex", files)).toBe("main.tex");
+  });
+
+  it("returns the file itself when there is no root at all", () => {
+    const files = [tex("notes.tex", "Just notes")];
+    expect(resolveTexRoot("notes.tex", files)).toBe("notes.tex");
+  });
+});
+
+describe("findIncludingRoots", () => {
+  it("does not treat \\includegraphics as a file include", () => {
+    const files = [
+      tex("main.tex", `${ROOT}\\includegraphics{fig}\n\\end{document}`),
+      tex("fig.tex", "not a figure"),
+    ];
+    expect(findIncludingRoots("fig.tex", files)).toEqual([]);
+  });
+});
+
+describe("collectProjectLabels", () => {
+  it("collects labels from other tex files only", () => {
+    const files = [
+      tex("main.tex", "\\label{sec:main}"),
+      tex("sections/a.tex", "\\label{ fig:a }\n\\label{eq:1}"),
+    ];
+    const labels = collectProjectLabels(files, "main.tex");
+    expect([...labels].sort()).toEqual(["eq:1", "fig:a"]);
+  });
+});

--- a/apps/desktop/src/__tests__/stores/claude-chat-send-prompt.test.ts
+++ b/apps/desktop/src/__tests__/stores/claude-chat-send-prompt.test.ts
@@ -197,6 +197,26 @@ describe("useClaudeChatStore.sendPrompt context assembly", () => {
     );
   });
 
+  it("passes the Fable model alias and extended effort levels to Claude Code", async () => {
+    useClaudeChatStore.setState({
+      selectedProviderCredentialId: CLAUDE_CODE_PROVIDER_ID,
+      selectedModel: "fable",
+      effortLevel: "xhigh",
+    });
+
+    await useClaudeChatStore.getState().sendPrompt("Use Fable");
+
+    expect(invoke).toHaveBeenCalledWith(
+      "execute_claude_code",
+      expect.objectContaining({
+        model: "fable",
+        effortLevel: "xhigh",
+        providerCredentialId: null,
+        providerModelOverride: null,
+      }),
+    );
+  });
+
   it("starts Claude Code with prior context when switching from a direct provider", async () => {
     useClaudeChatStore.setState((state) => ({
       sessionId: "qwen-session",

--- a/apps/desktop/src/__tests__/stores/document-store.test.ts
+++ b/apps/desktop/src/__tests__/stores/document-store.test.ts
@@ -479,6 +479,124 @@ describe("useDocumentStore", () => {
     });
   });
 
+  describe("refreshFiles", () => {
+    function mockDisk(contents: Record<string, string>) {
+      vi.mocked(readDir).mockImplementation(async (dir: string | URL) => {
+        const dirPath = String(dir);
+        if (dirPath === "/project") {
+          return [
+            { name: "main.tex", isDirectory: false },
+            { name: "sections", isDirectory: true },
+          ] as any;
+        }
+        if (dirPath === "/project/sections") {
+          return [{ name: "intro.tex", isDirectory: false }] as any;
+        }
+        throw new Error(`Unexpected readDir path: ${dirPath}`);
+      });
+      vi.mocked(readTextFile).mockImplementation(async (path: string | URL) => {
+        const filePath = String(path);
+        if (filePath in contents) return contents[filePath];
+        throw new Error(`Unexpected readTextFile path: ${filePath}`);
+      });
+    }
+
+    const mainContent = "\\documentclass{article}\\input{sections/intro}";
+    const introContent = "\\section{Intro}";
+
+    beforeEach(() => {
+      useDocumentStore.setState({
+        files: [
+          makeFile({ content: mainContent }),
+          makeFile({
+            id: "sections/intro.tex",
+            name: "intro.tex",
+            relativePath: "sections/intro.tex",
+            absolutePath: "/project/sections/intro.tex",
+            content: introContent,
+          }),
+        ],
+        activeFileId: "main.tex",
+      });
+    });
+
+    it("keeps a file that became active while the refresh was in flight", async () => {
+      mockDisk({
+        "/project/main.tex": mainContent,
+        "/project/sections/intro.tex": introContent,
+      });
+      const store = useDocumentStore.getState();
+      const refresh = store.refreshFiles();
+      // User opens a section file while disk reads are still pending
+      store.setActiveFile("sections/intro.tex");
+      await refresh;
+
+      expect(useDocumentStore.getState().activeFileId).toBe(
+        "sections/intro.tex",
+      );
+    });
+
+    it("does not clobber edits made while the refresh was in flight", async () => {
+      mockDisk({
+        "/project/main.tex": mainContent,
+        "/project/sections/intro.tex": introContent,
+      });
+      const store = useDocumentStore.getState();
+      const refresh = store.refreshFiles();
+      store.updateFileContent("sections/intro.tex", "edited during refresh");
+      await refresh;
+
+      const intro = useDocumentStore
+        .getState()
+        .files.find((f) => f.id === "sections/intro.tex");
+      expect(intro?.content).toBe("edited during refresh");
+      expect(intro?.isDirty).toBe(true);
+    });
+
+    it("reloads clean files from disk and picks up new files", async () => {
+      vi.mocked(readDir).mockImplementation(async (dir: string | URL) => {
+        const dirPath = String(dir);
+        if (dirPath === "/project") {
+          return [
+            { name: "main.tex", isDirectory: false },
+            { name: "sections", isDirectory: true },
+          ] as any;
+        }
+        if (dirPath === "/project/sections") {
+          return [
+            { name: "intro.tex", isDirectory: false },
+            { name: "results.tex", isDirectory: false },
+          ] as any;
+        }
+        throw new Error(`Unexpected readDir path: ${dirPath}`);
+      });
+      vi.mocked(readTextFile).mockImplementation(async (path: string | URL) => {
+        const filePath = String(path);
+        if (filePath === "/project/main.tex") return mainContent;
+        if (filePath === "/project/sections/intro.tex") return "updated intro";
+        if (filePath === "/project/sections/results.tex") return "results";
+        throw new Error(`Unexpected readTextFile path: ${filePath}`);
+      });
+
+      await useDocumentStore.getState().refreshFiles();
+
+      const state = useDocumentStore.getState();
+      expect(state.files.map((f) => f.id)).toEqual([
+        "main.tex",
+        "sections/intro.tex",
+        "sections/results.tex",
+      ]);
+      expect(
+        state.files.find((f) => f.id === "sections/intro.tex")?.content,
+      ).toBe("updated intro");
+      expect(
+        state.files.find((f) => f.id === "sections/results.tex")?.content,
+      ).toBe("results");
+      expect(state.folders).toEqual(["sections"]);
+      expect(state.activeFileId).toBe("main.tex");
+    });
+  });
+
   describe("saveFile", () => {
     beforeEach(() => {
       vi.mocked(writeTextFile).mockClear();

--- a/apps/desktop/src/components/claude-chat/chat-composer.tsx
+++ b/apps/desktop/src/components/claude-chat/chat-composer.tsx
@@ -2,6 +2,7 @@ import {
   type CSSProperties,
   type FC,
   type KeyboardEvent,
+  type ReactNode,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -27,6 +28,7 @@ import {
   SparklesIcon,
   RabbitIcon,
   LayersIcon,
+  GemIcon,
   PlusIcon,
   Trash2Icon,
   Loader2Icon,
@@ -39,6 +41,9 @@ import { join, tempDir } from "@tauri-apps/api/path";
 import { invoke } from "@tauri-apps/api/core";
 import {
   CLAUDE_CODE_PROVIDER_ID,
+  type ClaudeModelSelector,
+  EFFORT_LEVELS,
+  type EffortLevel,
   loadSelectedProviderCredentialId,
   offsetToLineCol,
   type PromptContextOverride,
@@ -187,11 +192,21 @@ function formatGuidanceText(guidance: QueuedGuidance) {
     : guidance.prompt;
 }
 
-type EffortLevel = "low" | "medium" | "high";
-const EFFORT_LEVELS: EffortLevel[] = ["low", "medium", "high"];
-
 function effortShortLabel(level: EffortLevel) {
-  return level === "low" ? "L" : level === "medium" ? "M" : "H";
+  switch (level) {
+    case "low":
+      return "L";
+    case "medium":
+      return "M";
+    case "high":
+      return "H";
+    case "xhigh":
+      return "XH";
+    case "max":
+      return "MAX";
+    default:
+      return level;
+  }
 }
 
 function effortDisplayLabel(level: EffortLevel) {
@@ -200,6 +215,8 @@ function effortDisplayLabel(level: EffortLevel) {
 
 function claudeModelDisplayName(model: string) {
   switch (model) {
+    case "fable":
+      return "Fable";
     case "sonnet":
       return "Sonnet";
     case "opus":
@@ -1246,7 +1263,18 @@ export const ChatComposer: FC<{ isOpen?: boolean }> = ({ isOpen }) => {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [modelPickerOpen]);
 
-  const claudeModelOptions = [
+  const claudeModelOptions: {
+    id: ClaudeModelSelector;
+    name: string;
+    desc: string;
+    icon: ReactNode;
+  }[] = [
+    {
+      id: "fable" as const,
+      name: "Fable",
+      desc: "Most intelligent, hardest problems (Fable 5.1)",
+      icon: <GemIcon className="size-3.5" />,
+    },
     {
       id: "sonnet" as const,
       name: "Sonnet",
@@ -1256,7 +1284,7 @@ export const ChatComposer: FC<{ isOpen?: boolean }> = ({ isOpen }) => {
     {
       id: "opus" as const,
       name: "Opus",
-      desc: "Most capable, complex reasoning",
+      desc: "Highly capable, complex reasoning",
       icon: <SparklesIcon className="size-3.5" />,
     },
     {

--- a/apps/desktop/src/components/workspace/editor/latex-editor.tsx
+++ b/apps/desktop/src/components/workspace/editor/latex-editor.tsx
@@ -58,6 +58,7 @@ import {
   resolveCompileTarget,
   formatCompileError,
 } from "@/lib/latex-compiler";
+import { filterProjectDiagnostics } from "@/lib/latex-diagnostics";
 import { useSettingsStore } from "@/stores/settings-store";
 import { EditorToolbar } from "./editor-toolbar";
 import { SelectionToolbar, type ToolbarAction } from "./selection-toolbar";
@@ -649,7 +650,12 @@ export function LatexEditor() {
                   return [];
                 }
                 const baseLinter = latexLinter();
-                const diagnostics = baseLinter(view);
+                const lintState = useDocumentStore.getState();
+                const diagnostics = filterProjectDiagnostics(
+                  baseLinter(view),
+                  lintState.activeFileId,
+                  lintState.files,
+                );
                 return diagnostics.map((d: Diagnostic) => ({
                   ...d,
                   actions: [

--- a/apps/desktop/src/lib/latex-diagnostics.ts
+++ b/apps/desktop/src/lib/latex-diagnostics.ts
@@ -1,0 +1,38 @@
+import type { ProjectFile } from "@/stores/document-store";
+import { collectProjectLabels, resolveTexRoot } from "@/lib/tex-project";
+
+const MISSING_DOCUMENT_ENV_PREFIX = "Missing document environment";
+const UNDEFINED_LABEL_RE = /^Reference to undefined label: (.+)$/;
+
+/**
+ * Drop linter diagnostics that only make sense for a single-file document.
+ *
+ * In multi-file projects (`\input{sections/...}`), section files legitimately
+ * lack `\begin{document}` and reference labels defined in sibling files. The
+ * bundled LaTeX linter only sees one file at a time, so filter those findings
+ * using project-wide knowledge.
+ */
+export function filterProjectDiagnostics<T extends { message: string }>(
+  diagnostics: T[],
+  activeFileId: string,
+  files: ProjectFile[],
+): T[] {
+  if (diagnostics.length === 0) return diagnostics;
+  const activeFile = files.find((f) => f.id === activeFileId);
+  if (!activeFile || activeFile.type !== "tex") return diagnostics;
+
+  const isRootFile = resolveTexRoot(activeFileId, files) === activeFileId;
+  let externalLabels: Set<string> | null = null;
+
+  return diagnostics.filter((d) => {
+    if (!isRootFile && d.message.startsWith(MISSING_DOCUMENT_ENV_PREFIX)) {
+      return false;
+    }
+    const labelMatch = d.message.match(UNDEFINED_LABEL_RE);
+    if (labelMatch) {
+      externalLabels ??= collectProjectLabels(files, activeFileId);
+      if (externalLabels.has(labelMatch[1].trim())) return false;
+    }
+    return true;
+  });
+}

--- a/apps/desktop/src/lib/tex-project.ts
+++ b/apps/desktop/src/lib/tex-project.ts
@@ -1,0 +1,251 @@
+import type { ProjectFile } from "@/stores/document-store";
+
+const DOCUMENTCLASS_RE = /\\documentclass[\s{[]/;
+const MAGIC_ROOT_RE = /^%\s*!TEX\s+root\s*=\s*(.+)/i;
+/**
+ * Matches file-inclusion commands. Group 1 is the command, group 2 the first
+ * brace argument, group 3 the optional second brace argument (used by
+ * `\import{dir}{file}` and friends).
+ */
+const INCLUDE_RE =
+  /\\(input|include|subfile|subfileinclude|import|subimport|inputfrom|subinputfrom)\s*\{([^}]*)\}(?:\s*\{([^}]*)\})?/g;
+const LABEL_RE = /\\label\s*\{([^}]*)\}/g;
+const TEX_EXT_RE = /\.(tex|ltx)$/i;
+
+/** Normalize a project-relative path: forward slashes, no `.`/`..` segments. */
+export function normalizeTexPath(path: string): string {
+  const out: string[] = [];
+  for (const part of path.replace(/\\/g, "/").split("/")) {
+    if (part === "" || part === ".") continue;
+    if (part === "..") {
+      out.pop();
+      continue;
+    }
+    out.push(part);
+  }
+  return out.join("/");
+}
+
+function dirOf(relativePath: string): string {
+  const normalized = normalizeTexPath(relativePath);
+  const idx = normalized.lastIndexOf("/");
+  return idx === -1 ? "" : normalized.slice(0, idx);
+}
+
+function joinTexPath(dir: string, path: string): string {
+  return normalizeTexPath(dir ? `${dir}/${path}` : path);
+}
+
+/** Strip unescaped `%` comments so commented-out includes are ignored. */
+function stripComments(content: string): string {
+  return content.replace(/(^|[^\\])%.*$/gm, "$1");
+}
+
+export function isTexRootContent(content: string | undefined): boolean {
+  return !!content && DOCUMENTCLASS_RE.test(content);
+}
+
+function candidatePaths(target: string, baseDirs: string[]): string[] {
+  const trimmed = target.trim();
+  if (!trimmed) return [];
+  const variants = TEX_EXT_RE.test(trimmed)
+    ? [trimmed]
+    : [`${trimmed}.tex`, trimmed];
+  const out: string[] = [];
+  for (const dir of baseDirs) {
+    for (const variant of variants) out.push(joinTexPath(dir, variant));
+  }
+  return out;
+}
+
+/**
+ * Return the ids of project files that `file` includes via `\input`,
+ * `\include`, `\subfile`, `\import`, etc. Targets are resolved the way TeX
+ * does: relative to the project root (the compile cwd) and, as a fallback,
+ * relative to the including file's directory.
+ */
+export function extractIncludedFileIds(
+  file: ProjectFile,
+  byPath: Map<string, ProjectFile>,
+): string[] {
+  if (!file.content) return [];
+  const includerDir = dirOf(file.relativePath);
+  const text = stripComments(file.content);
+  const found: string[] = [];
+  for (const match of text.matchAll(INCLUDE_RE)) {
+    const cmd = match[1];
+    let target: string;
+    let baseDirs: string[];
+    if (
+      cmd === "import" ||
+      cmd === "subimport" ||
+      cmd === "inputfrom" ||
+      cmd === "subinputfrom"
+    ) {
+      if (match[3] === undefined) continue;
+      const dir = match[2].trim();
+      target = match[3];
+      baseDirs = cmd.startsWith("sub")
+        ? [joinTexPath(includerDir, dir)]
+        : [normalizeTexPath(dir), joinTexPath(includerDir, dir)];
+    } else {
+      target = match[2];
+      baseDirs = ["", includerDir];
+    }
+    for (const candidate of candidatePaths(target, baseDirs)) {
+      const resolved = byPath.get(candidate);
+      if (resolved) {
+        if (!found.includes(resolved.id)) found.push(resolved.id);
+        break;
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Find root documents (files containing `\documentclass`) that include
+ * `fileId`, directly or transitively.
+ */
+export function findIncludingRoots(
+  fileId: string,
+  files: ProjectFile[],
+): ProjectFile[] {
+  const texFiles = files.filter((f) => f.type === "tex");
+  const byPath = new Map(
+    texFiles.map((f) => [normalizeTexPath(f.relativePath), f] as const),
+  );
+  const byId = new Map(texFiles.map((f) => [f.id, f] as const));
+  const includeCache = new Map<string, string[]>();
+  const includesOf = (f: ProjectFile): string[] => {
+    let ids = includeCache.get(f.id);
+    if (!ids) {
+      ids = extractIncludedFileIds(f, byPath);
+      includeCache.set(f.id, ids);
+    }
+    return ids;
+  };
+  const reaches = (root: ProjectFile): boolean => {
+    const seen = new Set<string>([root.id]);
+    const stack = [root];
+    while (stack.length > 0) {
+      const current = stack.pop()!;
+      for (const id of includesOf(current)) {
+        if (id === fileId) return true;
+        if (seen.has(id)) continue;
+        seen.add(id);
+        const next = byId.get(id);
+        if (next) stack.push(next);
+      }
+    }
+    return false;
+  };
+  return texFiles.filter(
+    (f) => f.id !== fileId && isTexRootContent(f.content) && reaches(f),
+  );
+}
+
+function preferWellKnown(candidates: ProjectFile[]): ProjectFile | undefined {
+  return (
+    candidates.find(
+      (f) => f.name === "main.tex" || f.name === "document.tex",
+    ) ?? candidates[0]
+  );
+}
+
+/**
+ * Resolve the root .tex file for compilation.
+ *
+ * Priority order:
+ * 1. `% !TEX root = <file>` magic comment in the first 20 lines of the file
+ *    (resolved relative to the file's directory, then the project root)
+ * 2. The file itself, if it contains `\documentclass`
+ * 3. A `\documentclass` file that `\input`s / `\include`s this file
+ * 4. `main.tex` or `document.tex` that contains `\documentclass`
+ * 5. Any other .tex file in the project that contains `\documentclass`
+ * 6. Fallback: the file itself
+ */
+export function resolveTexRoot(fileId: string, files: ProjectFile[]): string {
+  // The store replaces the `files` array on every change, so a per-array memo
+  // is invalidated exactly when the answer might change. This keeps the
+  // include-graph walk off the hot render path of the PDF preview.
+  let memo = rootMemo.get(files);
+  if (!memo) {
+    memo = new Map();
+    rootMemo.set(files, memo);
+  }
+  const cached = memo.get(fileId);
+  if (cached !== undefined) return cached;
+  const resolved = resolveTexRootUncached(fileId, files);
+  memo.set(fileId, resolved);
+  return resolved;
+}
+
+const rootMemo = new WeakMap<ProjectFile[], Map<string, string>>();
+
+function resolveTexRootUncached(fileId: string, files: ProjectFile[]): string {
+  const file = files.find((f) => f.id === fileId);
+  if (!file || file.type !== "tex") return fileId;
+  const content = file.content ?? "";
+
+  // 1. Check for % !TEX root magic comment
+  for (const line of content.split("\n").slice(0, 20)) {
+    const match = line.match(MAGIC_ROOT_RE);
+    if (!match) continue;
+    const rootPath = match[1].trim();
+    const byPath = new Map(
+      files.map((f) => [normalizeTexPath(f.relativePath), f] as const),
+    );
+    const candidates = [
+      joinTexPath(dirOf(file.relativePath), rootPath),
+      normalizeTexPath(rootPath),
+    ];
+    for (const candidate of candidates) {
+      const target = byPath.get(candidate);
+      if (target) return target.id;
+    }
+    const baseName = normalizeTexPath(rootPath).split("/").pop();
+    const byName = files.find((f) => f.name === baseName);
+    if (byName) return byName.id;
+  }
+
+  // 2. If the current file contains \documentclass, it is a root file
+  if (isTexRootContent(content)) return fileId;
+
+  // 3. A root document that includes this file
+  const includers = findIncludingRoots(fileId, files);
+  if (includers.length > 0) return preferWellKnown(includers)!.id;
+
+  // 4. Look for main.tex or document.tex with \documentclass
+  const wellKnown = files.find(
+    (f) =>
+      (f.name === "main.tex" || f.name === "document.tex") &&
+      f.type === "tex" &&
+      isTexRootContent(f.content),
+  );
+  if (wellKnown) return wellKnown.id;
+
+  // 5. Any .tex file with \documentclass
+  const anyRoot = files.find(
+    (f) => f.type === "tex" && f.id !== fileId && isTexRootContent(f.content),
+  );
+  if (anyRoot) return anyRoot.id;
+
+  // 6. Fallback: the file itself
+  return fileId;
+}
+
+/** Collect every `\label{...}` defined in project .tex files other than `excludeId`. */
+export function collectProjectLabels(
+  files: ProjectFile[],
+  excludeId?: string,
+): Set<string> {
+  const labels = new Set<string>();
+  for (const f of files) {
+    if (f.type !== "tex" || f.id === excludeId || !f.content) continue;
+    for (const match of f.content.matchAll(LABEL_RE)) {
+      labels.add(match[1].trim());
+    }
+  }
+  return labels;
+}

--- a/apps/desktop/src/stores/claude-chat-store.ts
+++ b/apps/desktop/src/stores/claude-chat-store.ts
@@ -545,6 +545,23 @@ function mergeStreamingContent(
 
 const DEFAULT_TAB_ID = nextTabId();
 
+/**
+ * Model aliases understood by the Claude Code CLI `--model` flag.
+ * Each alias resolves to the latest model of that family.
+ */
+export const CLAUDE_MODEL_SELECTORS = [
+  "fable",
+  "opus",
+  "sonnet",
+  "haiku",
+  "opusplan",
+] as const;
+export type ClaudeModelSelector = (typeof CLAUDE_MODEL_SELECTORS)[number];
+
+/** Effort levels accepted by the Claude Code CLI (`CLAUDE_CODE_EFFORT_LEVEL`). */
+export const EFFORT_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
+export type EffortLevel = (typeof EFFORT_LEVELS)[number];
+
 interface ClaudeChatState {
   // ── Projected fields (from active tab — read by consumers) ──
   messages: ClaudeStreamMessage[];
@@ -589,16 +606,16 @@ interface ClaudeChatState {
   consumePendingPinnedContextRemovals: () => string[];
 
   /** Currently selected model (passed per-prompt to Claude CLI) */
-  selectedModel: "sonnet" | "opus" | "haiku" | "opusplan";
-  setSelectedModel: (model: "sonnet" | "opus" | "haiku" | "opusplan") => void;
+  selectedModel: ClaudeModelSelector;
+  setSelectedModel: (model: ClaudeModelSelector) => void;
   selectedProviderCredentialId: string | null;
   setSelectedProviderCredentialId: (credentialId: string | null) => void;
   selectedProviderModels: Record<string, string>;
   setSelectedProviderModel: (credentialId: string, model: string) => void;
 
-  /** Effort level for Opus 4.6 adaptive reasoning */
-  effortLevel: "low" | "medium" | "high";
-  setEffortLevel: (level: "low" | "medium" | "high") => void;
+  /** Effort level for adaptive reasoning (Opus 4.6+, Fable 5.x) */
+  effortLevel: EffortLevel;
+  setEffortLevel: (level: EffortLevel) => void;
 
   // Actions
   sendPrompt: (

--- a/apps/desktop/src/stores/document-store.ts
+++ b/apps/desktop/src/stores/document-store.ts
@@ -14,6 +14,7 @@ import {
   createDirectory,
   join,
   LARGE_FILE_THRESHOLD,
+  type FsProjectFile,
   type ProjectFileType,
 } from "@/lib/tauri/fs";
 import { useHistoryStore } from "@/stores/history-store";
@@ -24,6 +25,9 @@ import { clearZoomCache } from "@/components/workspace/preview/pdf-preview";
 import { clearEditorStateCache } from "@/components/workspace/editor/latex-editor";
 import { useProjectStore } from "@/stores/project-store";
 import { createLogger } from "@/lib/debug/logger";
+import { resolveTexRoot } from "@/lib/tex-project";
+
+export { resolveTexRoot };
 
 const log = createLogger("document");
 const PROJECT_RENAME_LOCK_RETRY_DELAYS_MS = [150, 300, 600, 1000];
@@ -153,62 +157,6 @@ interface DocumentState {
 
 function getActiveFile(state: { files: ProjectFile[]; activeFileId: string }) {
   return state.files.find((f) => f.id === state.activeFileId);
-}
-
-/**
- * Resolve the root .tex file for compilation.
- *
- * Priority order:
- * 1. `% !TEX root = <file>` magic comment in the first 20 lines of the active file
- * 2. The file itself, if it contains `\documentclass`
- * 3. `main.tex` or `document.tex` that contains `\documentclass`
- * 4. Any other .tex file in the project that contains `\documentclass`
- * 5. Fallback: the active file itself
- */
-export function resolveTexRoot(fileId: string, files: ProjectFile[]): string {
-  const file = files.find((f) => f.id === fileId);
-  if (!file || file.type !== "tex" || !file.content) return fileId;
-
-  // 1. Check for % !TEX root magic comment
-  const lines = file.content.split("\n").slice(0, 20);
-  for (const line of lines) {
-    const match = line.match(/^%\s*!TEX\s+root\s*=\s*(.+)/i);
-    if (match) {
-      const rootPath = match[1].trim();
-      const target =
-        files.find((f) => f.relativePath === rootPath) ??
-        files.find((f) => f.name === rootPath);
-      if (target) return target.id;
-    }
-  }
-
-  // 2. If the current file contains \documentclass, it is a root file
-  if (/\\documentclass[\s{[]/.test(file.content)) {
-    return fileId;
-  }
-
-  // 3. Look for main.tex or document.tex with \documentclass
-  const wellKnown = files.find(
-    (f) =>
-      (f.name === "main.tex" || f.name === "document.tex") &&
-      f.type === "tex" &&
-      f.content &&
-      /\\documentclass[\s{[]/.test(f.content),
-  );
-  if (wellKnown) return wellKnown.id;
-
-  // 4. Any .tex file with \documentclass
-  const anyRoot = files.find(
-    (f) =>
-      f.type === "tex" &&
-      f.id !== fileId &&
-      f.content &&
-      /\\documentclass[\s{[]/.test(f.content),
-  );
-  if (anyRoot) return anyRoot.id;
-
-  // 5. Fallback: the active file itself
-  return fileId;
 }
 
 /** Re-key the external PDF bytes cache when a file is renamed/moved. */
@@ -1085,103 +1033,129 @@ export const useDocumentStore = create<DocumentState>()((set, get) => ({
   },
 
   refreshFiles: async () => {
-    const { projectRoot, files, activeFileId } = get();
+    const { projectRoot, files: filesAtStart } = get();
     if (!projectRoot) return;
 
     const { files: fsFiles, folders: fsFolders } =
       await scanProjectFolder(projectRoot);
-    const existingMap = new Map(files.map((f) => [f.relativePath, f]));
+    const startMap = new Map(filesAtStart.map((f) => [f.relativePath, f]));
     const diskPaths = new Set(fsFiles.map((f) => f.relativePath));
 
-    const merged: ProjectFile[] = [];
+    // Phase 1 (async): read disk contents. Nothing is committed to the store
+    // here, because the user may edit or switch files while this runs.
+    type DiskEntry = {
+      fsFile: FsProjectFile;
+      content?: string;
+      dataUrl?: string;
+      contentLoaded: boolean;
+    };
+    const diskEntries: DiskEntry[] = [];
 
     for (const fsFile of fsFiles) {
-      const existing = existingMap.get(fsFile.relativePath);
+      const existing = startMap.get(fsFile.relativePath);
+      const entry: DiskEntry = { fsFile, contentLoaded: false };
+      const isText =
+        fsFile.type === "tex" ||
+        fsFile.type === "bib" ||
+        fsFile.type === "style" ||
+        fsFile.type === "other";
+      const isLargeNonEssential =
+        fsFile.type === "other" && fsFile.fileSize > LARGE_FILE_THRESHOLD;
 
       if (existing) {
-        // Existing file — reload content from disk unless the user has unsaved edits
-        if (existing.isDirty) {
-          merged.push(existing);
-        } else {
-          const updated = { ...existing, fileSize: fsFile.fileSize };
-          if (
-            updated.type === "tex" ||
-            updated.type === "bib" ||
-            updated.type === "style" ||
-            updated.type === "other"
-          ) {
-            const isLargeNonEssential =
-              updated.type === "other" &&
-              fsFile.fileSize > LARGE_FILE_THRESHOLD;
-            // Only reload if it was previously loaded (not a skipped large file)
-            if (!isLargeNonEssential || updated.content !== undefined) {
-              try {
-                updated.content = await readTexFileContent(
-                  updated.absolutePath,
-                );
-              } catch {
-                /* keep previous content */
-              }
-            }
-          }
-          merged.push(updated);
-        }
-      } else {
-        // New file on disk
-        const pf: ProjectFile = {
-          id: fsFile.relativePath,
-          name: fsFile.relativePath.split(/[/\\]/).pop() || fsFile.relativePath,
-          relativePath: fsFile.relativePath,
-          absolutePath: fsFile.absolutePath,
-          type: fsFile.type,
-          isDirty: false,
-          fileSize: fsFile.fileSize,
-        };
-        const isLargeNonEssential =
-          pf.type === "other" && fsFile.fileSize > LARGE_FILE_THRESHOLD;
+        // Existing file — reload content from disk unless the user has unsaved
+        // edits. Skipped large files stay unloaded unless previously loaded.
         if (
-          pf.type === "tex" ||
-          pf.type === "bib" ||
-          pf.type === "style" ||
-          (pf.type === "other" && !isLargeNonEssential)
+          !existing.isDirty &&
+          isText &&
+          (!isLargeNonEssential || existing.content !== undefined)
         ) {
           try {
-            pf.content = await readTexFileContent(pf.absolutePath);
+            entry.content = await readTexFileContent(existing.absolutePath);
+            entry.contentLoaded = true;
           } catch {
-            /* skip unreadable */
-          }
-        } else if (
-          pf.type === "image" &&
-          fsFile.fileSize <= LARGE_FILE_THRESHOLD
-        ) {
-          try {
-            pf.dataUrl = await readImageAsDataUrl(pf.absolutePath);
-          } catch {
-            /* skip unreadable */
+            /* keep previous content */
           }
         }
-        // PDF files and large files are loaded on-demand
-        merged.push(pf);
+      } else if (isText && !isLargeNonEssential) {
+        try {
+          entry.content = await readTexFileContent(fsFile.absolutePath);
+          entry.contentLoaded = true;
+        } catch {
+          /* skip unreadable */
+        }
+      } else if (
+        fsFile.type === "image" &&
+        fsFile.fileSize <= LARGE_FILE_THRESHOLD
+      ) {
+        try {
+          entry.dataUrl = await readImageAsDataUrl(fsFile.absolutePath);
+        } catch {
+          /* skip unreadable */
+        }
       }
+      // PDF files and large files are loaded on-demand
+      diskEntries.push(entry);
     }
 
-    // Keep dirty files that were deleted from disk (user hasn't saved yet)
-    for (const f of files) {
-      if (!diskPaths.has(f.relativePath) && f.isDirty) {
-        merged.push(f);
+    // Phase 2 (sync): merge against the *latest* store state so that edits,
+    // saves, and active-file switches made during phase 1 are not clobbered.
+    set((s) => {
+      const currentMap = new Map(s.files.map((f) => [f.relativePath, f]));
+      const merged: ProjectFile[] = [];
+
+      for (const { fsFile, content, dataUrl, contentLoaded } of diskEntries) {
+        const current = currentMap.get(fsFile.relativePath);
+        if (current) {
+          const unchangedSinceScan =
+            current === startMap.get(fsFile.relativePath);
+          const updated =
+            current.fileSize === fsFile.fileSize
+              ? current
+              : { ...current, fileSize: fsFile.fileSize };
+          // If the in-memory file changed while we were reading (edit, save,
+          // rename), the disk snapshot may be stale — keep the live version.
+          if (contentLoaded && unchangedSinceScan && !current.isDirty) {
+            merged.push({ ...updated, content });
+          } else {
+            merged.push(updated);
+          }
+        } else {
+          // New file on disk
+          const pf: ProjectFile = {
+            id: fsFile.relativePath,
+            name:
+              fsFile.relativePath.split(/[/\\]/).pop() || fsFile.relativePath,
+            relativePath: fsFile.relativePath,
+            absolutePath: fsFile.absolutePath,
+            type: fsFile.type,
+            isDirty: false,
+            fileSize: fsFile.fileSize,
+          };
+          if (contentLoaded) pf.content = content;
+          if (dataUrl !== undefined) pf.dataUrl = dataUrl;
+          merged.push(pf);
+        }
       }
-    }
 
-    const newActiveId = merged.some((f) => f.id === activeFileId)
-      ? activeFileId
-      : (merged[0]?.id ?? "");
+      // Keep dirty files that were deleted from disk (user hasn't saved yet)
+      for (const f of s.files) {
+        if (!diskPaths.has(f.relativePath) && f.isDirty) {
+          merged.push(f);
+        }
+      }
 
-    set((s) => ({
-      files: merged,
-      folders: fsFolders,
-      activeFileId: newActiveId,
-      contentGeneration: s.contentGeneration + 1,
-    }));
+      const newActiveId = merged.some((f) => f.id === s.activeFileId)
+        ? s.activeFileId
+        : (merged[0]?.id ?? "");
+
+      return {
+        files: merged,
+        folders: fsFolders,
+        activeFileId: newActiveId,
+        contentGeneration: s.contentGeneration + 1,
+      };
+    });
   },
 
   loadFileContent: async (id) => {


### PR DESCRIPTION
…ssing fonts

- Use filename-only tex_input_name so xdvipdfmx resolves "main.xdv" instead of "subdir/main.xdv" when the main file lives in a subdirectory.
- Enable continue_on_errors and treat a produced PDF as success even when tectonic reports warning-level "errors"; fall back to a manual xdvipdfmx xdv->pdf pass when the conversion step is skipped.
- Set FONTCONFIG_PATH on Windows so xdvipdfmx can locate and embed fonts.
- Surface tectonic and subprocess stderr for easier diagnosis.